### PR TITLE
Refine turn UX and enforce double-rent legality

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -192,6 +192,14 @@ button:disabled {
   text-align: left;
 }
 
+.actions button,
+.play-option,
+.play-cancel {
+  white-space: normal;
+  overflow-wrap: anywhere;
+  line-height: 1.2;
+}
+
 .action-detail {
   display: block;
   margin-top: 0.16rem;
@@ -217,6 +225,17 @@ button:disabled {
 
 .debug-actions {
   margin-top: 0.55rem;
+}
+
+.debug-action-list {
+  margin: 0.5rem 0 0;
+  padding-left: 1.2rem;
+  max-height: 220px;
+  overflow: auto;
+}
+
+.debug-action-list li {
+  margin: 0.2rem 0;
 }
 
 .error {
@@ -342,6 +361,10 @@ footer {
   font-size: 0.72rem;
   line-height: 1.2;
   color: #1f2b34;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
 }
 
 .card-subtitle {
@@ -350,12 +373,19 @@ footer {
   line-height: 1.2;
   color: #5c6973;
   text-transform: capitalize;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
 }
 
 .card-meta {
   font-size: 0.56rem;
   line-height: 1.2;
   color: #314452;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .card-annotation {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -571,8 +571,6 @@ function App() {
     if (!game || !prompt) return null;
     const over = isGameOver(game);
     const winner = game.players.find((player) => player.id === over.winnerId);
-    const topPanelActions = isMandatoryPrompt ? [] : contextualActions;
-
     return (
       <section className="panel game-panel">
         <div className="game-top">
@@ -601,28 +599,17 @@ function App() {
 
         <section className="action-panel">
           <h3>Turn Actions</h3>
-          <div className="actions action-list">
-            {topPanelActions.map((item, index) => (
-              <button key={`${item.label}-${index}`} onClick={() => runAction(item.action)} disabled={over.done}>
-                {item.label}
-              </button>
-            ))}
-            {topPanelActions.length === 0 && (
-              <p>{isMandatoryPrompt ? 'Resolve the required action in the active player panel.' : 'Play cards from your hand.'}</p>
-            )}
-          </div>
+          <p>{isMandatoryPrompt ? 'Resolve the required action in the active player panel.' : 'Use the active player panel below to play cards.'}</p>
           <div className="debug-actions">
             <button type="button" onClick={() => setShowDebugActions((prev) => !prev)}>
               {showDebugActions ? 'Hide' : 'Show'} All Legal Actions ({legalActions.length})
             </button>
             {showDebugActions && (
-              <div className="actions action-list">
+              <ul className="debug-action-list">
                 {legalActions.map((item, index) => (
-                  <button key={`debug-${item.label}-${index}`} onClick={() => runAction(item.action)} disabled={over.done}>
-                    {item.label}
-                  </button>
+                  <li key={`debug-${item.label}-${index}`}>{item.label}</li>
                 ))}
-              </div>
+              </ul>
             )}
           </div>
         </section>

--- a/src/engine/game.ts
+++ b/src/engine/game.ts
@@ -242,6 +242,26 @@ function canCardBePlacedInColor(card: CardDefinition, color: PropertyColor): boo
   return false;
 }
 
+function hasPlayableRentCard(player: PlayerState, excludedCardId?: string): boolean {
+  for (const handCardId of player.hand) {
+    if (handCardId === excludedCardId) continue;
+    const handCard = getCardDefinition(handCardId);
+    if (handCard.kind !== 'action') continue;
+    if (handCard.actionKind !== 'rent' && handCard.actionKind !== 'rent_wild') continue;
+    const allowedColors = Object.keys(handCard.rentMatrix ?? {}) as PropertyColor[];
+    if (allowedColors.some((color) => player.properties[color].length > 0)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function canPlayDoubleRent(state: GameState, player: PlayerState, excludedCardId: string): boolean {
+  const hasPlayBudgetForCombo = state.turn.playsUsed <= MAX_PLAYS_PER_TURN - 2;
+  if (!hasPlayBudgetForCombo) return false;
+  return hasPlayableRentCard(player, excludedCardId);
+}
+
 function discard(state: GameState, cardId: string): void {
   state.discardPile.push(cardId);
 }
@@ -522,11 +542,21 @@ function legalPlayActions(state: GameState, player: PlayerState): LegalAction[] 
         const actionKind = card.actionKind as ActionKind;
         if (actionKind === 'just_say_no') continue;
 
-        if (actionKind === 'pass_go' || actionKind === 'double_rent' || actionKind === 'its_my_birthday') {
+        if (actionKind === 'pass_go' || actionKind === 'its_my_birthday') {
           actions.push({
             label: `Play ${card.name}`,
             action: { type: 'play_action', playerId: player.id, cardId },
           });
+          continue;
+        }
+
+        if (actionKind === 'double_rent') {
+          if (canPlayDoubleRent(state, player, cardId)) {
+            actions.push({
+              label: `Play ${card.name}`,
+              action: { type: 'play_action', playerId: player.id, cardId },
+            });
+          }
           continue;
         }
 
@@ -783,6 +813,12 @@ export function applyAction(currentState: GameState, action: Action): ApplyResul
 
       if (actionKind === 'deal_breaker' && validatedTarget && completeSetColors(validatedTarget).length === 0) {
         return setErr(error('invalid_action', 'Target has no complete property sets.'));
+      }
+
+      if (actionKind === 'double_rent') {
+        if (!canPlayDoubleRent(state, player, action.cardId)) {
+          return setErr(error('invalid_action', 'Double Rent requires a playable rent card this turn.'));
+        }
       }
 
       if (actionKind === 'rent' || actionKind === 'rent_wild') {

--- a/src/test/card-ui.test.tsx
+++ b/src/test/card-ui.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
 import { CardView } from '../ui/components/CardView';
+import { getCardVisualModel } from '../ui/cards';
 
 describe('Card UI', () => {
   it('renders property, action, money, and wild card faces', () => {
@@ -37,5 +38,26 @@ describe('Card UI', () => {
     render(<CardView cardId="money_1#1" faceUp={false} />);
 
     expect(screen.getByRole('button', { name: /hidden card/i })).toBeInTheDocument();
+  });
+
+  it('maps every property color to the matching theme and CSS variable', () => {
+    const cases = [
+      { cardId: 'brown_1#1', themeClass: 'theme-brown', accent: 'var(--card-color-brown)' },
+      { cardId: 'light_blue_1#1', themeClass: 'theme-light-blue', accent: 'var(--card-color-light-blue)' },
+      { cardId: 'pink_1#1', themeClass: 'theme-pink', accent: 'var(--card-color-pink)' },
+      { cardId: 'orange_1#1', themeClass: 'theme-orange', accent: 'var(--card-color-orange)' },
+      { cardId: 'red_1#1', themeClass: 'theme-red', accent: 'var(--card-color-red)' },
+      { cardId: 'yellow_1#1', themeClass: 'theme-yellow', accent: 'var(--card-color-yellow)' },
+      { cardId: 'green_1#1', themeClass: 'theme-green', accent: 'var(--card-color-green)' },
+      { cardId: 'dark_blue_1#1', themeClass: 'theme-dark-blue', accent: 'var(--card-color-dark-blue)' },
+      { cardId: 'railroad_1#1', themeClass: 'theme-railroad', accent: 'var(--card-color-railroad)' },
+      { cardId: 'utility_1#1', themeClass: 'theme-utility', accent: 'var(--card-color-utility)' },
+    ];
+
+    for (const testCase of cases) {
+      const model = getCardVisualModel(testCase.cardId);
+      expect(model.themeClass).toBe(testCase.themeClass);
+      expect(model.accent).toBe(testCase.accent);
+    }
   });
 });

--- a/src/test/engine.test.ts
+++ b/src/test/engine.test.ts
@@ -344,4 +344,40 @@ describe('engine basics', () => {
     expect(legal.length).toBeGreaterThan(0);
     expect(legal.every((item) => !item.label.includes('#'))).toBe(true);
   });
+
+  it('does not allow double rent without a playable rent follow-up', () => {
+    const state = mkState();
+    state.players[0].hand = ['double_rent#d1', 'money_1#m1'];
+    state.players[0].properties.brown = [{ cardId: 'brown_1#p1b1', assignedColor: 'brown' }];
+
+    const legal = getLegalActions(state, 'p1');
+    expect(legal.some((item) => item.action.type === 'play_action' && item.action.cardId === 'double_rent#d1')).toBe(false);
+
+    const result = applyAction(state, {
+      type: 'play_action',
+      playerId: 'p1',
+      cardId: 'double_rent#d1',
+    });
+    expect(result.error?.code).toBe('invalid_action');
+    expect(result.state.players[0].hand).toContain('double_rent#d1');
+  });
+
+  it('does not allow double rent when only one play remains', () => {
+    const state = mkState();
+    state.turn.playsUsed = 2;
+    state.players[0].hand = ['double_rent#d1', 'rent_color#r1'];
+    state.players[0].properties.brown = [{ cardId: 'brown_1#p1b1', assignedColor: 'brown' }];
+
+    const legal = getLegalActions(state, 'p1');
+    expect(legal.some((item) => item.action.type === 'play_action' && item.action.cardId === 'double_rent#d1')).toBe(false);
+  });
+
+  it('allows double rent only when a rent card can still be played this turn', () => {
+    const state = mkState();
+    state.players[0].hand = ['double_rent#d1', 'rent_color#r1'];
+    state.players[0].properties.brown = [{ cardId: 'brown_1#p1b1', assignedColor: 'brown' }];
+
+    const legal = getLegalActions(state, 'p1');
+    expect(legal.some((item) => item.action.type === 'play_action' && item.action.cardId === 'double_rent#d1')).toBe(true);
+  });
 });


### PR DESCRIPTION
- Remove duplicate top-level action execution path and keep one primary action surface in the active player panel

- Convert legal-actions debug panel to read-only list to prevent redundant action triggers

- Prevent Double Rent unless a playable rent follow-up exists and enough plays remain

- Centralize double-rent eligibility check for both legal-action generation and runtime validation

- Improve action/card text overflow handling and add regression tests for color mapping and double-rent rules