### PR TITLE
Add required discard flow and improve turn guidance UI

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -187,6 +187,16 @@ button:disabled {
   margin: 0.2rem 0 0.35rem;
 }
 
+.inline-discard-hint {
+  margin: 0.2rem 0 0.35rem;
+  padding: 0.35rem 0.5rem;
+  border-radius: 8px;
+  border: 1px solid #e1c58e;
+  background: #fff3dc;
+  color: #6e4a12;
+  font-size: 0.88rem;
+}
+
 .inline-actions button {
   text-align: left;
 }
@@ -224,6 +234,23 @@ button:disabled {
 
 .debug-actions {
   margin-top: 0.55rem;
+}
+
+.turn-status {
+  margin: 0.15rem 0 0.45rem;
+  padding: 0.42rem 0.55rem;
+  border-radius: 8px;
+  border: 1px solid #d2c8b7;
+  background: #f7f3ea;
+  color: #4c5c67;
+  font-size: 0.92rem;
+}
+
+.turn-status.is-required {
+  border-color: #ddb067;
+  background: #fff5df;
+  color: #6a4a16;
+  font-weight: 600;
 }
 
 .debug-action-list {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -62,6 +62,7 @@ function actionToCardId(action: Action): string | null {
   if (action.type === 'play_to_bank') return action.cardId;
   if (action.type === 'play_property') return action.cardId;
   if (action.type === 'play_action') return action.cardId;
+  if (action.type === 'discard_card') return action.cardId;
   if (action.type === 'counter_response' && action.useJustSayNo && action.cardId) return action.cardId;
   return null;
 }
@@ -183,10 +184,32 @@ function App() {
     () => legalActions.filter((item) => !actionToCardId(item.action)),
     [legalActions],
   );
-  const isMandatoryPrompt = Boolean(prompt && (prompt.kind === 'payment' || prompt.kind === 'selection' || prompt.kind === 'response'));
+  const isMandatoryPrompt = Boolean(
+    prompt && (prompt.kind === 'payment' || prompt.kind === 'selection' || prompt.kind === 'response' || prompt.kind === 'discard'),
+  );
   const mainPhaseExhausted = Boolean(
     game && prompt?.kind === 'main' && game.turn.phase === 'action' && game.turn.playsUsed >= 3 && !game.pending,
   );
+  const discardOverLimitCount = useMemo(() => {
+    if (!game || !prompt || prompt.kind !== 'discard') return 0;
+    const activePlayer = game.players.find((player) => player.id === prompt.playerId);
+    if (!activePlayer) return 0;
+    return Math.max(activePlayer.hand.length - 7, 0);
+  }, [game, prompt]);
+  const turnStatusText = useMemo(() => {
+    if (!prompt) return '';
+    if (prompt.kind === 'discard') {
+      return discardOverLimitCount > 0
+        ? `Discard ${discardOverLimitCount} card${discardOverLimitCount === 1 ? '' : 's'} to end turn.`
+        : 'Discard step complete. You can pass turn.';
+    }
+    if (prompt.kind === 'payment') return 'Payment is required before any other action.';
+    if (prompt.kind === 'response') return 'Respond to Just Say No chain.';
+    if (prompt.kind === 'selection') return 'Resolve the pending card effect.';
+    if (prompt.kind === 'draw') return 'Draw to start the turn.';
+    if (mainPhaseExhausted) return '3/3 plays used. Pass turn or use non-play actions.';
+    return 'Play cards from hand or pass turn.';
+  }, [discardOverLimitCount, mainPhaseExhausted, prompt]);
 
   const pendingPayment = game?.pending?.kind === 'payment' ? game.pending.payload : null;
   const pendingPaymentPlayer = useMemo(() => {
@@ -451,6 +474,12 @@ function App() {
               {mainPhaseExhausted && (
                 <p className="inline-must-act">3/3 plays used. Pass turn or use non-play actions.</p>
               )}
+              {prompt?.kind === 'discard' && (
+                <p className="inline-discard-hint">
+                  Hand size: <strong>{player.hand.length}</strong> | Limit: <strong>7</strong> | Need to discard:{' '}
+                  <strong>{Math.max(player.hand.length - 7, 0)}</strong>
+                </p>
+              )}
               {prompt && <p className="inline-prompt-text">{prompt.text}</p>}
               {isPaymentPayer && pendingPayment ? (
                 <div className="payment-panel">
@@ -479,7 +508,9 @@ function App() {
                     {actionDetailText(item) ? <span className="action-detail">{actionDetailText(item)}</span> : null}
                   </button>
                 ))}
-                {inlineActions.length === 0 && !pendingPayment && <p>Play cards from your hand.</p>}
+                {inlineActions.length === 0 && !pendingPayment && (
+                  <p>{prompt?.kind === 'discard' ? 'Discard from your hand to continue.' : 'Play cards from your hand.'}</p>
+                )}
               </div>
               {turnSnapshots.length > 0 && prompt?.kind === 'main' ? (
                 <div className="actions inline-actions">
@@ -600,6 +631,7 @@ function App() {
 
         <section className="action-panel">
           <h3>Turn Actions</h3>
+          <p className={`turn-status ${isMandatoryPrompt ? 'is-required' : ''}`}>{turnStatusText}</p>
           <p>{isMandatoryPrompt ? 'Resolve the required action in the active player panel.' : 'Use the active player panel below to play cards.'}</p>
           <div className="debug-actions">
             <button type="button" onClick={() => setShowDebugActions((prev) => !prev)}>

--- a/src/engine/game.ts
+++ b/src/engine/game.ts
@@ -23,7 +23,7 @@ import type {
   TurnPrompt,
 } from './types';
 
-const MAX_HAND_AT_END_TURN = 7;
+export const MAX_HAND_AT_END_TURN = 7;
 const MAX_PLAYS_PER_TURN = 3;
 const PROPERTY_COLORS = Object.keys(PROPERTY_SET_SIZES) as PropertyColor[];
 
@@ -270,10 +270,14 @@ function nextPlayerIndex(state: GameState, fromIndex = state.currentPlayerIndex)
   return (fromIndex + 1) % state.players.length;
 }
 
+function requiresEndTurnDiscard(state: GameState, player: PlayerState): boolean {
+  return !state.pending && state.turn.phase === 'action' && getCurrentPlayer(state).id === player.id && player.hand.length > MAX_HAND_AT_END_TURN;
+}
+
 function finishTurn(state: GameState, events: GameEvent[]): RuleError | undefined {
   const current = getCurrentPlayer(state);
   if (current.hand.length > MAX_HAND_AT_END_TURN) {
-    return error('invalid_action', `You must discard to 7 cards or fewer (currently ${current.hand.length}).`);
+    return error('hand_limit', `You must discard to 7 cards or fewer (currently ${current.hand.length}).`);
   }
   state.currentPlayerIndex = nextPlayerIndex(state);
   state.turn = { phase: 'draw', playsUsed: 0, doubleRentMultiplier: 1 };
@@ -665,6 +669,13 @@ export function getLegalActions(state: GameState, playerId: PlayerId): LegalActi
   if (!player) return [];
   if (state.winnerId) return [];
 
+  if (requiresEndTurnDiscard(state, player)) {
+    return player.hand.map((cardId) => ({
+      label: `Discard ${cardLabel(cardId)}`,
+      action: { type: 'discard_card', playerId, cardId },
+    }));
+  }
+
   const pendingActions = legalForPending(state, player);
   if (pendingActions.length > 0) return pendingActions;
   if (state.pending) return [];
@@ -712,6 +723,13 @@ export function applyAction(currentState: GameState, action: Action): ApplyResul
     if (state.turn.phase !== 'action') return setErr(error('invalid_phase', 'Cannot pass now.'));
     const err = finishTurn(state, events);
     if (err) return setErr(err);
+  }
+
+  if (action.type === 'discard_card') {
+    if (!requiresEndTurnDiscard(state, player)) return setErr(error('invalid_action', 'Discard is only allowed when over the hand limit at end of turn.'));
+    if (!removeFromHand(player, action.cardId)) return setErr(error('insufficient_cards', 'Card not in hand.'));
+    discard(state, action.cardId);
+    pushEvent(events, 'discard', `${player.name} discarded ${cardLabel(action.cardId)}.`);
   }
 
   if (action.type === 'play_to_bank') {
@@ -1103,6 +1121,14 @@ export function isGameOver(state: GameState): { done: boolean; winnerId?: Player
 
 export function getNextPrompt(state: GameState): TurnPrompt {
   const currentPlayer = getCurrentPlayer(state);
+  if (requiresEndTurnDiscard(state, currentPlayer)) {
+    return {
+      playerId: currentPlayer.id,
+      text: `${currentPlayer.name}: discard down to ${MAX_HAND_AT_END_TURN} cards to end your turn.`,
+      kind: 'discard',
+    };
+  }
+
   if (state.pending?.kind === 'counter') {
     const pendingPlayer = getPlayer(state, state.pending.payload.awaitingPlayerId);
     return {

--- a/src/engine/types.ts
+++ b/src/engine/types.ts
@@ -119,6 +119,7 @@ export type RuleErrorCode =
   | 'invalid_phase'
   | 'invalid_turn'
   | 'invalid_action'
+  | 'hand_limit'
   | 'invalid_target'
   | 'illegal_play_limit'
   | 'insufficient_cards'
@@ -137,6 +138,7 @@ export type Action =
   | { type: 'play_property'; playerId: PlayerId; cardId: string; color: PropertyColor }
   | { type: 'move_wild'; playerId: PlayerId; cardId: string; fromColor: PropertyColor; toColor: PropertyColor }
   | { type: 'play_action'; playerId: PlayerId; cardId: string; targetPlayerId?: PlayerId; color?: PropertyColor }
+  | { type: 'discard_card'; playerId: PlayerId; cardId: string }
   | { type: 'counter_response'; playerId: PlayerId; useJustSayNo: boolean; cardId?: string }
   | { type: 'pay_request'; playerId: PlayerId; cards: string[] }
   | { type: 'sly_deal_pick'; playerId: PlayerId; cardId: string; sourceColor: PropertyColor; destinationColor: PropertyColor }
@@ -161,5 +163,5 @@ export interface ApplyResult {
 export interface TurnPrompt {
   playerId: PlayerId;
   text: string;
-  kind: 'draw' | 'main' | 'response' | 'payment' | 'selection';
+  kind: 'draw' | 'main' | 'response' | 'payment' | 'selection' | 'discard';
 }

--- a/src/test/app.test.tsx
+++ b/src/test/app.test.tsx
@@ -208,4 +208,45 @@ describe('App', () => {
     fireEvent.click(screen.getByRole('button', { name: /undo last play/i }));
     expect(screen.queryByRole('button', { name: /undo last play/i })).not.toBeInTheDocument();
   });
+
+  it('treats discard as a required prompt and discards selected hand card', () => {
+    const discardState: GameState = {
+      ...structuredClone(baseState),
+      players: [
+        {
+          ...structuredClone(baseState.players[0]),
+          hand: ['money_1#a1', 'money_2#a2', 'money_3#a3', 'money_4#a4', 'money_5#a5', 'pass_go#a6', 'rent_color#a7', 'debt_collector#a8'],
+        },
+        structuredClone(baseState.players[1]),
+      ],
+      turn: { ...baseState.turn, playsUsed: 3 },
+    };
+    mockedCreateGame.mockImplementationOnce(() => discardState);
+    mockedGetNextPrompt.mockImplementation(() => ({
+      playerId: 'p1',
+      text: 'Alpha: discard down to 7 cards to end your turn.',
+      kind: 'discard',
+    }));
+    mockedGetLegalActions.mockImplementation(() => [
+      {
+        label: 'Discard $1 Money',
+        action: { type: 'discard_card', playerId: 'p1', cardId: 'money_1#a1' },
+      },
+    ]);
+
+    render(<App />);
+
+    fireEvent.click(screen.getByRole('button', { name: /new game/i }));
+    fireEvent.click(screen.getByRole('button', { name: /start match/i }));
+    fireEvent.click(screen.getByRole('button', { name: /reveal turn/i }));
+
+    expect(screen.getByText(/required: resolve this step/i)).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /\$1 card/i }));
+
+    expect(mockedApplyAction).toHaveBeenCalledWith(expect.anything(), {
+      type: 'discard_card',
+      playerId: 'p1',
+      cardId: 'money_1#a1',
+    });
+  });
 });

--- a/src/test/engine.test.ts
+++ b/src/test/engine.test.ts
@@ -323,6 +323,45 @@ describe('engine basics', () => {
     expect(targetC?.requiresPropertyTransfer).toBe(true);
   });
 
+  it('requires discard when ending a turn above hand limit', () => {
+    const state = createGame({
+      seed: 29,
+      players: [
+        { id: 'p1', name: 'A' },
+        { id: 'p2', name: 'B' },
+      ],
+    });
+    state.currentPlayerIndex = 0;
+    state.turn.phase = 'action';
+    state.turn.playsUsed = 3;
+    state.pending = null;
+    state.players[0].hand = [
+      'money_1#x1',
+      'money_2#x2',
+      'money_3#x3',
+      'money_4#x4',
+      'money_5#x5',
+      'pass_go#x6',
+      'rent_color#x7',
+      'debt_collector#x8',
+    ];
+
+    const blockedPass = applyAction(state, { type: 'pass_turn', playerId: 'p1' });
+    expect(blockedPass.error?.code).toBe('hand_limit');
+
+    const legal = getLegalActions(state, 'p1');
+    expect(legal.length).toBe(8);
+    expect(legal.every((item) => item.action.type === 'discard_card')).toBe(true);
+
+    const afterDiscard = applyAction(state, { type: 'discard_card', playerId: 'p1', cardId: 'money_1#x1' }).state;
+    expect(afterDiscard.players[0].hand.length).toBe(7);
+    expect(afterDiscard.discardPile).toContain('money_1#x1');
+
+    const passAfterDiscard = applyAction(afterDiscard, { type: 'pass_turn', playerId: 'p1' });
+    expect(passAfterDiscard.error).toBeUndefined();
+    expect(passAfterDiscard.state.currentPlayerIndex).toBe(1);
+  });
+
   it('uses friendly labels in forced deal pending actions', () => {
     const state = createGame({
       seed: 25,


### PR DESCRIPTION
## What changed
- add a required end-of-turn discard flow when hand size is above 7
- introduce discard_card legal actions and discard prompt handling
- return a dedicated hand_limit error when pass turn is blocked
- wire hand-card clicks to discard actions in the app
- improve turn guidance UI with required-action status and discard progress hints
- add tests for engine discard enforcement and app discard interaction

## Validation
- npm test
