### PR TITLE
Fix pending rent target actions visibility in selection flow

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -457,7 +457,13 @@ function App() {
       const isPaymentPayer = pendingPayment?.targetPlayerId === player.id;
       const paymentSelectionEnabled = Boolean(isPaymentPayer && revealedPlayerId === player.id && !isGameOver(state).done);
       const inlineActions = isPromptPlayer
-        ? (pendingPayment ? contextualActions.filter((item) => item.action.type !== 'pay_request') : contextualActions)
+        ? (
+            pendingPayment
+              ? contextualActions.filter((item) => item.action.type !== 'pay_request')
+              : prompt?.kind === 'selection'
+                ? legalActions
+                : contextualActions
+          )
         : [];
       const propertyColors = (Object.keys(player.properties) as PropertyColor[]).filter((color) => player.properties[color].length > 0);
 

--- a/src/test/app.test.tsx
+++ b/src/test/app.test.tsx
@@ -249,4 +249,44 @@ describe('App', () => {
       cardId: 'money_1#a1',
     });
   });
+
+  it('renders pending selection play actions in inline actions and runs target choice', () => {
+    mockedGetNextPrompt.mockImplementation(() => ({
+      playerId: 'p1',
+      text: 'Alpha: resolve the pending card effect.',
+      kind: 'selection',
+    }));
+    mockedGetLegalActions.mockImplementation(() => [
+      {
+        label: 'Charge Beta rent for Green',
+        action: {
+          type: 'play_action',
+          playerId: 'p1',
+          cardId: 'rent_green_dark_blue#r1',
+          targetPlayerId: 'p2',
+          color: 'green',
+        },
+        targetPlayerId: 'p2',
+        requestedAmount: 8,
+        collectibleCap: 3,
+        requiresPropertyTransfer: true,
+      },
+    ]);
+
+    render(<App />);
+
+    fireEvent.click(screen.getByRole('button', { name: /new game/i }));
+    fireEvent.click(screen.getByRole('button', { name: /start match/i }));
+    fireEvent.click(screen.getByRole('button', { name: /reveal turn/i }));
+
+    fireEvent.click(screen.getByRole('button', { name: /charge beta rent for green/i }));
+
+    expect(mockedApplyAction).toHaveBeenCalledWith(expect.anything(), {
+      type: 'play_action',
+      playerId: 'p1',
+      cardId: 'rent_green_dark_blue#r1',
+      targetPlayerId: 'p2',
+      color: 'green',
+    });
+  });
 });


### PR DESCRIPTION
Show all legal actions in the active-player inline panel during selection prompts so rent target choices remain clickable after playing Double Rent + Rent.

Add an app regression test that verifies a pending-selection rent target play_action is rendered and executed.