### PR TITLE
Add full-screen post-match summary experience

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -281,6 +281,287 @@ button:disabled {
   margin-top: 1rem;
 }
 
+.postgame-panel {
+  position: relative;
+  overflow: hidden;
+  background:
+    radial-gradient(circle at 10% 10%, rgba(255, 215, 128, 0.38), transparent 34%),
+    radial-gradient(circle at 90% 0%, rgba(123, 211, 199, 0.28), transparent 42%),
+    linear-gradient(170deg, #fffbef, #f5efe2 52%, #efe8d7);
+  border-color: #d4c3a0;
+}
+
+.postgame-panel::before {
+  content: '';
+  position: absolute;
+  inset: auto -80px -130px auto;
+  width: 320px;
+  height: 320px;
+  border-radius: 50%;
+  background: radial-gradient(circle at center, rgba(199, 119, 30, 0.22), rgba(199, 119, 30, 0));
+  pointer-events: none;
+}
+
+.postgame-hero {
+  position: relative;
+  z-index: 1;
+  text-align: left;
+}
+
+.postgame-kicker {
+  display: inline-block;
+  margin: 0;
+  padding: 0.2rem 0.55rem;
+  border-radius: 999px;
+  background: #e9dfcb;
+  color: #475463;
+  font-weight: 700;
+  letter-spacing: 0.01em;
+  font-size: 0.82rem;
+  text-transform: uppercase;
+}
+
+.postgame-hero h2 {
+  margin-top: 0.45rem;
+  font-size: clamp(1.7rem, 3.8vw, 2.6rem);
+  color: #1f2e3a;
+}
+
+.postgame-hero p {
+  margin: 0.4rem 0 0;
+  font-size: 1rem;
+  color: #42515d;
+  max-width: 68ch;
+}
+
+.postgame-meta {
+  font-size: 0.86rem !important;
+  color: #5c6b77 !important;
+}
+
+.postgame-kpis {
+  position: relative;
+  z-index: 1;
+  margin-top: 1rem;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 0.65rem;
+}
+
+.postgame-kpi {
+  background: rgba(255, 255, 255, 0.82);
+  border: 1px solid #dfd0b4;
+  border-radius: 12px;
+  padding: 0.7rem 0.8rem;
+}
+
+.postgame-kpi h3 {
+  font-size: 0.82rem;
+  color: #5b6772;
+  text-transform: uppercase;
+  letter-spacing: 0.01em;
+}
+
+.postgame-kpi p {
+  margin: 0.25rem 0 0;
+  color: #26343e;
+  font-size: 1.3rem;
+  font-weight: 800;
+}
+
+.postgame-standings {
+  position: relative;
+  z-index: 1;
+  margin-top: 1rem;
+  border-radius: 14px;
+  border: 1px solid #daccb2;
+  background: rgba(255, 255, 255, 0.88);
+  padding: 0.9rem;
+}
+
+.postgame-heading-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.postgame-standing-list {
+  list-style: none;
+  margin: 0.6rem 0 0;
+  padding: 0;
+  display: grid;
+  gap: 0.55rem;
+}
+
+.postgame-standing {
+  border: 1px solid #ded3be;
+  border-radius: 12px;
+  background: #fdf9f1;
+  padding: 0.65rem 0.7rem;
+}
+
+.postgame-standing.is-winner {
+  border-color: #cb9836;
+  background: linear-gradient(140deg, #fff9e8, #f8f0db);
+  box-shadow: 0 0 0 2px rgba(203, 152, 54, 0.14);
+}
+
+.postgame-standing-head {
+  display: flex;
+  align-items: baseline;
+  gap: 0.55rem;
+}
+
+.postgame-rank {
+  margin: 0;
+  color: #8f5f11;
+  font-weight: 800;
+  font-size: 0.94rem;
+}
+
+.postgame-name {
+  margin: 0;
+  color: #22313b;
+  font-weight: 700;
+}
+
+.postgame-standing-stats {
+  margin-top: 0.35rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.34rem;
+}
+
+.postgame-standing-stats span {
+  font-size: 0.78rem;
+  color: #495863;
+  border-radius: 999px;
+  border: 1px solid #d8cdb9;
+  background: #fff;
+  padding: 0.17rem 0.45rem;
+}
+
+.postgame-highlights {
+  position: relative;
+  z-index: 1;
+  margin-top: 1rem;
+  padding: 0.9rem;
+  border-radius: 14px;
+  border: 1px dashed #d7c6a4;
+  background: rgba(255, 251, 242, 0.95);
+}
+
+.postgame-highlights h3 {
+  margin-bottom: 0.35rem;
+}
+
+.postgame-highlights p {
+  margin: 0;
+  color: #2f3f4b;
+}
+
+.postgame-highlights ul {
+  margin: 0.6rem 0 0;
+  padding-left: 1.1rem;
+  color: #4d5d68;
+  display: grid;
+  gap: 0.28rem;
+}
+
+.postgame-accessibility {
+  position: relative;
+  z-index: 1;
+  margin-top: 0.9rem;
+  display: grid;
+  gap: 0.3rem;
+}
+
+.postgame-toggle {
+  margin: 0;
+  display: flex;
+  align-items: center;
+  gap: 0.45rem;
+  font-size: 0.86rem;
+}
+
+.postgame-toggle input {
+  width: 1rem;
+  height: 1rem;
+}
+
+.postgame-actions {
+  position: relative;
+  z-index: 1;
+  margin-top: 0.9rem;
+}
+
+.postgame-actions button {
+  min-height: 48px;
+  padding: 0.7rem 1rem;
+}
+
+.postgame-primary-action {
+  background: linear-gradient(140deg, #196a4f, #124f3b);
+  box-shadow: 0 8px 16px rgba(25, 106, 79, 0.22);
+}
+
+.postgame-celebration {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  overflow: hidden;
+  z-index: 0;
+}
+
+.confetti-dot {
+  position: absolute;
+  top: -28px;
+  width: 9px;
+  height: 13px;
+  border-radius: 3px;
+  opacity: 0;
+  animation: confetti-fall 760ms ease-out forwards;
+}
+
+.confetti-dot:nth-child(5n + 1) {
+  background: #db6545;
+}
+
+.confetti-dot:nth-child(5n + 2) {
+  background: #2c8a6f;
+}
+
+.confetti-dot:nth-child(5n + 3) {
+  background: #d5a239;
+}
+
+.confetti-dot:nth-child(5n + 4) {
+  background: #3d6999;
+}
+
+.confetti-dot:nth-child(5n + 5) {
+  background: #8a4f2d;
+}
+
+.confetti-dot:nth-child(1) { left: 4%; animation-delay: 10ms; }
+.confetti-dot:nth-child(2) { left: 11%; animation-delay: 30ms; }
+.confetti-dot:nth-child(3) { left: 17%; animation-delay: 50ms; }
+.confetti-dot:nth-child(4) { left: 23%; animation-delay: 80ms; }
+.confetti-dot:nth-child(5) { left: 29%; animation-delay: 20ms; }
+.confetti-dot:nth-child(6) { left: 35%; animation-delay: 100ms; }
+.confetti-dot:nth-child(7) { left: 41%; animation-delay: 40ms; }
+.confetti-dot:nth-child(8) { left: 47%; animation-delay: 70ms; }
+.confetti-dot:nth-child(9) { left: 53%; animation-delay: 90ms; }
+.confetti-dot:nth-child(10) { left: 58%; animation-delay: 60ms; }
+.confetti-dot:nth-child(11) { left: 63%; animation-delay: 40ms; }
+.confetti-dot:nth-child(12) { left: 68%; animation-delay: 20ms; }
+.confetti-dot:nth-child(13) { left: 73%; animation-delay: 80ms; }
+.confetti-dot:nth-child(14) { left: 78%; animation-delay: 50ms; }
+.confetti-dot:nth-child(15) { left: 83%; animation-delay: 30ms; }
+.confetti-dot:nth-child(16) { left: 88%; animation-delay: 70ms; }
+.confetti-dot:nth-child(17) { left: 93%; animation-delay: 110ms; }
+.confetti-dot:nth-child(18) { left: 97%; animation-delay: 35ms; }
+
 .shield {
   position: fixed;
   inset: 0;
@@ -780,6 +1061,31 @@ footer {
   }
 }
 
+@keyframes confetti-fall {
+  from {
+    opacity: 0;
+    transform: translateY(-16px) rotate(0deg);
+  }
+  20% {
+    opacity: 1;
+  }
+  to {
+    opacity: 0;
+    transform: translateY(210px) rotate(140deg);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .card-enter {
+    animation: none;
+  }
+
+  .confetti-dot {
+    animation: none;
+    opacity: 0;
+  }
+}
+
 @media (max-width: 720px) {
   main {
     padding: 1rem;
@@ -810,5 +1116,9 @@ footer {
   .card-size-lg {
     width: 94px;
     height: 134px;
+  }
+
+  .postgame-standing-stats span {
+    font-size: 0.73rem;
   }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,14 +21,21 @@ import {
   saveLifetimeStats,
   saveMatchHistory,
 } from './persistence/storage';
-import { applyMatchToLifetime, buildMatchRecord, type LifetimeStatsV1, type MatchRecordV1 } from './stats';
+import {
+  applyMatchToLifetime,
+  buildMatchRecord,
+  buildPostGameSummary,
+  type LifetimeStatsV1,
+  type MatchRecordV1,
+  type PostGameSummary,
+} from './stats';
 import { CardView } from './ui/components/CardView';
 import { HandFan } from './ui/components/HandFan';
 import { PlayChooser, type ActionVariantView } from './ui/components/PlayChooser';
 import { RecentEvents } from './ui/components/RecentEvents';
 import './App.css';
 
-type Screen = 'home' | 'setup' | 'game' | 'stats';
+type Screen = 'home' | 'setup' | 'game' | 'stats' | 'game_over';
 
 interface SetupState {
   playerCount: number;
@@ -88,9 +95,20 @@ function shouldRetainTurnSnapshots(nextState: GameState, nextPromptPlayerId: str
   return nextState.pending.kind === 'rent' || nextState.pending.kind === 'sly_deal' || nextState.pending.kind === 'forced_deal' || nextState.pending.kind === 'deal_breaker';
 }
 
+function formatDuration(seconds: number): string {
+  if (seconds < 60) return `${seconds}s`;
+  const minutes = Math.floor(seconds / 60);
+  const remainingSeconds = seconds % 60;
+  if (minutes < 60) return `${minutes}m ${remainingSeconds}s`;
+  const hours = Math.floor(minutes / 60);
+  const remainingMinutes = minutes % 60;
+  return `${hours}h ${remainingMinutes}m`;
+}
+
 function App() {
   const [screen, setScreen] = useState<Screen>('home');
   const [game, setGame] = useState<GameState | null>(null);
+  const [postGameSummary, setPostGameSummary] = useState<PostGameSummary | null>(null);
   const [setup, setSetup] = useState<SetupState>(initialSetup);
   const [error, setError] = useState<string | null>(null);
   const [revealedPlayerId, setRevealedPlayerId] = useState<string | null>(null);
@@ -100,18 +118,42 @@ function App() {
   const [selectedCardId, setSelectedCardId] = useState<string | null>(null);
   const [selectedPaymentCards, setSelectedPaymentCards] = useState<string[]>([]);
   const [showDebugActions, setShowDebugActions] = useState(false);
+  const [reduceCelebrationEffects, setReduceCelebrationEffects] = useState(false);
+  const [prefersReducedMotion, setPrefersReducedMotion] = useState(false);
   const [turnSnapshots, setTurnSnapshots] = useState<GameState[]>([]);
+  const postGameTitleRef = useRef<HTMLHeadingElement | null>(null);
   const finalizedMatchRef = useRef<string | null>(null);
 
   useEffect(() => {
-    if (!game) return;
+    if (!game || isGameOver(game).done) return;
     const handle = window.setTimeout(() => {
       saveActiveGame(game);
     }, 220);
     return () => window.clearTimeout(handle);
   }, [game]);
 
+  useEffect(() => {
+    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return;
+    const query = window.matchMedia('(prefers-reduced-motion: reduce)');
+    const syncPreference = () => {
+      setPrefersReducedMotion(query.matches);
+    };
+    syncPreference();
+    if (typeof query.addEventListener === 'function') {
+      query.addEventListener('change', syncPreference);
+      return () => query.removeEventListener('change', syncPreference);
+    }
+    query.addListener(syncPreference);
+    return () => query.removeListener(syncPreference);
+  }, []);
+
+  useEffect(() => {
+    if (screen !== 'game_over') return;
+    postGameTitleRef.current?.focus();
+  }, [screen, postGameSummary?.endedAt]);
+
   const prompt = useMemo(() => (game ? getNextPrompt(game) : null), [game]);
+  const celebrationEnabled = Boolean(postGameSummary && !prefersReducedMotion && !reduceCelebrationEffects);
 
   useEffect(() => {
     if (!game || !prompt) {
@@ -237,14 +279,10 @@ function App() {
     ? selectedPaymentCards.length > 0 && (selectedPaymentTotal >= pendingPayment.amount || totalPayableValue < pendingPayment.amount)
     : false;
 
-  const startNewGame = () => {
-    const players: PlayerConfig[] = setup.playerNames.slice(0, setup.playerCount).map((name, index) => ({
-      id: `p${index + 1}`,
-      name: name.trim() || `Player ${index + 1}`,
-    }));
-
-    const nextGame = createGame({ players, deckVersion: 'v1' });
+  const openGame = useCallback((nextGame: GameState) => {
+    finalizedMatchRef.current = null;
     setGame(nextGame);
+    setPostGameSummary(null);
     setRevealedPlayerId(null);
     setScreen('game');
     setError(null);
@@ -252,6 +290,19 @@ function App() {
     setSelectedCardId(null);
     setSelectedPaymentCards([]);
     setTurnSnapshots([]);
+  }, []);
+
+  const startGameWithPlayers = useCallback((players: PlayerConfig[]) => {
+    const nextGame = createGame({ players, deckVersion: 'v1' });
+    openGame(nextGame);
+  }, [openGame]);
+
+  const startNewGame = () => {
+    const players: PlayerConfig[] = setup.playerNames.slice(0, setup.playerCount).map((name, index) => ({
+      id: `p${index + 1}`,
+      name: name.trim() || `Player ${index + 1}`,
+    }));
+    startGameWithPlayers(players);
   };
 
   const resumeGame = () => {
@@ -260,14 +311,17 @@ function App() {
       setError('No active saved game found.');
       return;
     }
-    setGame(saved.gameState);
-    setRevealedPlayerId(null);
-    setScreen('game');
-    setError(null);
-    setChooser(null);
-    setSelectedCardId(null);
-    setSelectedPaymentCards([]);
-    setTurnSnapshots([]);
+    if (isGameOver(saved.gameState).done) {
+      const loadedLifetime = loadLifetimeStats();
+      setLifetime(loadedLifetime);
+      setGame(saved.gameState);
+      setPostGameSummary(buildPostGameSummary(saved.gameState, loadedLifetime));
+      setScreen('game_over');
+      setError(null);
+      clearActiveGame();
+      return;
+    }
+    openGame(saved.gameState);
   };
 
   const finalizeIfGameOver = (nextState: GameState) => {
@@ -283,6 +337,13 @@ function App() {
     const nextLifetime = applyMatchToLifetime(loadLifetimeStats(), matchRecord);
     saveLifetimeStats(nextLifetime);
     setLifetime(nextLifetime);
+    setPostGameSummary(buildPostGameSummary(nextState, nextLifetime));
+    setRevealedPlayerId(null);
+    setChooser(null);
+    setSelectedCardId(null);
+    setSelectedPaymentCards([]);
+    setTurnSnapshots([]);
+    setScreen('game_over');
     clearActiveGame();
   };
 
@@ -375,6 +436,168 @@ function App() {
     if (item.requestedAmount == null || item.collectibleCap == null) return null;
     const detail = `Ask $${item.requestedAmount}, likely collect up to $${item.collectibleCap}`;
     return item.requiresPropertyTransfer ? `${detail} (likely requires property transfer)` : detail;
+  };
+
+  const syncSetupPlayerNames = useCallback((names: string[]) => {
+    setSetup((prev) => {
+      const nextNames = [...prev.playerNames];
+      for (let index = 0; index < 4; index += 1) {
+        if (index < names.length) {
+          nextNames[index] = names[index];
+        } else if (!nextNames[index]?.trim()) {
+          nextNames[index] = `Player ${index + 1}`;
+        }
+      }
+      return {
+        ...prev,
+        playerCount: Math.min(4, Math.max(2, names.length)),
+        playerNames: nextNames,
+      };
+    });
+  }, []);
+
+  const goHome = useCallback(() => {
+    clearActiveGame();
+    setGame(null);
+    setPostGameSummary(null);
+    setScreen('home');
+    setError(null);
+    setChooser(null);
+    setSelectedCardId(null);
+    setSelectedPaymentCards([]);
+    setTurnSnapshots([]);
+    setShowDebugActions(false);
+  }, []);
+
+  const startRematch = useCallback(() => {
+    if (!game) return;
+    const playerNames = game.players.map((player) => player.name);
+    syncSetupPlayerNames(playerNames);
+    startGameWithPlayers(
+      playerNames.map((name, index) => ({
+        id: `p${index + 1}`,
+        name,
+      })),
+    );
+  }, [game, startGameWithPlayers, syncSetupPlayerNames]);
+
+  const renderGameOver = () => {
+    if (!postGameSummary) return null;
+
+    const endedLabel = new Date(postGameSummary.endedAt).toLocaleString();
+
+    return (
+      <section className={`panel postgame-panel card-enter ${celebrationEnabled ? 'has-celebration' : ''}`} aria-labelledby="postgame-title">
+        {celebrationEnabled && (
+          <div className="postgame-celebration" aria-hidden="true">
+            {Array.from({ length: 18 }, (_, index) => (
+              <span key={`confetti-${index}`} className="confetti-dot" />
+            ))}
+          </div>
+        )}
+
+        <header className="postgame-hero">
+          <p className="postgame-kicker">Match Complete</p>
+          <h2 id="postgame-title" ref={postGameTitleRef} tabIndex={-1}>
+            {postGameSummary.winnerName ?? 'Unknown Player'} Wins!
+          </h2>
+          <p>
+            {postGameSummary.winnerName ?? 'The winner'} completed three full property sets and closed out the match.
+          </p>
+          <p className="postgame-meta">Finished {endedLabel}</p>
+        </header>
+
+        <section className="postgame-kpis" aria-label="Match stats">
+          <article className="postgame-kpi">
+            <h3>Turns</h3>
+            <p>{postGameSummary.turnCount}</p>
+          </article>
+          <article className="postgame-kpi">
+            <h3>Duration</h3>
+            <p>{formatDuration(postGameSummary.durationSec)}</p>
+          </article>
+          <article className="postgame-kpi">
+            <h3>Total Events</h3>
+            <p>{postGameSummary.totalEvents}</p>
+          </article>
+        </section>
+
+        <section className="postgame-standings" aria-labelledby="standings-title">
+          <div className="postgame-heading-row">
+            <h3 id="standings-title">Final Standings</h3>
+          </div>
+          <ul className="postgame-standing-list">
+            {postGameSummary.players.map((row) => (
+              <li key={row.playerId} className={`postgame-standing ${row.isWinner ? 'is-winner' : ''}`}>
+                <div className="postgame-standing-head">
+                  <p className="postgame-rank">#{row.rank}</p>
+                  <p className="postgame-name">{row.name}</p>
+                </div>
+                <div className="postgame-standing-stats">
+                  <span>{row.completeSets} complete sets</span>
+                  <span>${row.bankValue} bank value</span>
+                  <span>{row.propertyCardCount} property cards</span>
+                  <span>{row.handCount} cards in hand</span>
+                  <span>${row.totalCardValue} total card value</span>
+                  <span>
+                    Lifetime: {row.lifetimeWins} wins / {row.lifetimeGamesPlayed} games
+                  </span>
+                </div>
+              </li>
+            ))}
+          </ul>
+        </section>
+
+        <section className="postgame-highlights" aria-labelledby="highlights-title">
+          <h3 id="highlights-title">Highlights</h3>
+          <p>
+            <strong>Final swing:</strong> {postGameSummary.finalSwing}
+          </p>
+          <ul>
+            {postGameSummary.recentEvents.map((event, index) => (
+              <li key={`${event.timestamp}-${event.type}-${index}`}>
+                {event.message}
+              </li>
+            ))}
+          </ul>
+        </section>
+
+        <section className="postgame-accessibility">
+          <label className="postgame-toggle">
+            <input
+              type="checkbox"
+              checked={reduceCelebrationEffects}
+              onChange={(event) => setReduceCelebrationEffects(event.target.checked)}
+            />
+            Reduce celebration effects
+          </label>
+          {prefersReducedMotion && (
+            <small>System reduced-motion preference is enabled.</small>
+          )}
+        </section>
+
+        <div className="actions postgame-actions">
+          <button className="postgame-primary-action" onClick={startRematch} disabled={!game}>
+            Play Rematch
+          </button>
+          <button
+            onClick={() => {
+              const names = game?.players.map((player) => player.name);
+              if (names && names.length > 0) {
+                syncSetupPlayerNames(names);
+              }
+              setScreen('setup');
+              setPostGameSummary(null);
+              setError(null);
+            }}
+          >
+            New Match Setup
+          </button>
+          <button onClick={() => setScreen('stats')}>View Stats</button>
+          <button onClick={goHome}>Home</button>
+        </div>
+      </section>
+    );
   };
 
   const renderHome = () => (
@@ -608,7 +831,6 @@ function App() {
   const renderGame = () => {
     if (!game || !prompt) return null;
     const over = isGameOver(game);
-    const winner = game.players.find((player) => player.id === over.winnerId);
     return (
       <section className="panel game-panel">
         <div className="game-top">
@@ -619,19 +841,10 @@ function App() {
               Turn {game.turnCount} | Draw pile: {game.drawPile.length} | Discard: {game.discardPile.length}
             </p>
             {game.turn.phase === 'action' && <p>Plays used: {game.turn.playsUsed}/3</p>}
-            {over.done && <p className="winner">Winner: {winner?.name ?? 'Unknown'}</p>}
           </div>
           <div className="actions">
             <button onClick={() => setScreen('home')}>Home</button>
-            <button
-              onClick={() => {
-                clearActiveGame();
-                setGame(null);
-                setScreen('home');
-              }}
-            >
-              End Match
-            </button>
+            <button onClick={goHome}>End Match</button>
           </div>
         </div>
 
@@ -737,6 +950,7 @@ function App() {
       {screen === 'setup' && renderSetup()}
       {screen === 'game' && renderGame()}
       {screen === 'stats' && renderStats()}
+      {screen === 'game_over' && renderGameOver()}
 
       <footer>
         <small>Monopoly Deal local pass-and-play.</small>

--- a/src/stats/index.ts
+++ b/src/stats/index.ts
@@ -1,2 +1,3 @@
 export * from './types';
 export * from './records';
+export * from './postGame';

--- a/src/stats/postGame.ts
+++ b/src/stats/postGame.ts
@@ -1,0 +1,135 @@
+import { getCardDefinition, type PropertyColor } from '../cards/catalog';
+import { getSetCompletionCount, type GameEvent, type GameState, type PlayerState } from '../engine';
+import type { LifetimeStatsV1 } from './types';
+
+export interface PostGamePlayerRow {
+  playerId: string;
+  name: string;
+  rank: number;
+  isWinner: boolean;
+  completeSets: number;
+  bankValue: number;
+  propertyCardCount: number;
+  handCount: number;
+  totalCardValue: number;
+  lifetimeWins: number;
+  lifetimeGamesPlayed: number;
+}
+
+export interface PostGameSummary {
+  winnerId?: string;
+  winnerName?: string;
+  endedAt: number;
+  turnCount: number;
+  durationSec: number;
+  totalEvents: number;
+  finalSwing: string;
+  players: PostGamePlayerRow[];
+  recentEvents: GameEvent[];
+}
+
+interface RankedPlayer {
+  player: PlayerState;
+  completeSets: number;
+  bankValue: number;
+  propertyCardCount: number;
+  handCount: number;
+  totalCardValue: number;
+}
+
+function cardMoneyValue(cardId: string): number {
+  const definition = getCardDefinition(cardId);
+  return definition.moneyValue ?? definition.value;
+}
+
+function totalZoneValue(cardIds: string[]): number {
+  return cardIds.reduce((sum, cardId) => sum + cardMoneyValue(cardId), 0);
+}
+
+function countPropertyCards(player: PlayerState): number {
+  return (Object.keys(player.properties) as PropertyColor[]).reduce(
+    (sum, color) => sum + player.properties[color].length,
+    0,
+  );
+}
+
+function totalPropertyValue(player: PlayerState): number {
+  return (Object.keys(player.properties) as PropertyColor[]).reduce(
+    (sum, color) => sum + totalZoneValue(player.properties[color].map((card) => card.cardId)),
+    0,
+  );
+}
+
+function rankPlayers(state: GameState): RankedPlayer[] {
+  const ranked = state.players.map((player) => {
+    const completeSets = getSetCompletionCount(player);
+    const bankValue = totalZoneValue(player.bank);
+    const propertyCardCount = countPropertyCards(player);
+    const handCount = player.hand.length;
+    const totalCardValue = bankValue + totalPropertyValue(player) + totalZoneValue(player.hand);
+    return {
+      player,
+      completeSets,
+      bankValue,
+      propertyCardCount,
+      handCount,
+      totalCardValue,
+    };
+  });
+
+  ranked.sort((left, right) => {
+    if (right.completeSets !== left.completeSets) return right.completeSets - left.completeSets;
+    if (right.bankValue !== left.bankValue) return right.bankValue - left.bankValue;
+    if (right.propertyCardCount !== left.propertyCardCount) return right.propertyCardCount - left.propertyCardCount;
+    if (left.handCount !== right.handCount) return left.handCount - right.handCount;
+    return left.player.name.localeCompare(right.player.name);
+  });
+
+  return ranked;
+}
+
+function finalSwingMessage(events: GameEvent[]): string {
+  const impactful = new Set(['deal_breaker', 'forced_deal', 'sly_deal', 'rent_target', 'pay', 'counter', 'action', 'property']);
+  for (let index = events.length - 1; index >= 0; index -= 1) {
+    const event = events[index];
+    if (impactful.has(event.type)) {
+      return event.message;
+    }
+  }
+  if (events.length === 0) return 'No key swing captured this match.';
+  return events[events.length - 1].message;
+}
+
+export function buildPostGameSummary(state: GameState, lifetimeStats: LifetimeStatsV1): PostGameSummary {
+  const ranked = rankPlayers(state);
+  const winner = state.players.find((player) => player.id === state.winnerId);
+
+  const players = ranked.map((entry, index) => {
+    const lifetime = lifetimeStats.players[entry.player.name];
+    return {
+      playerId: entry.player.id,
+      name: entry.player.name,
+      rank: index + 1,
+      isWinner: entry.player.id === state.winnerId,
+      completeSets: entry.completeSets,
+      bankValue: entry.bankValue,
+      propertyCardCount: entry.propertyCardCount,
+      handCount: entry.handCount,
+      totalCardValue: entry.totalCardValue,
+      lifetimeWins: lifetime?.wins ?? 0,
+      lifetimeGamesPlayed: lifetime?.gamesPlayed ?? 0,
+    };
+  });
+
+  return {
+    winnerId: state.winnerId,
+    winnerName: winner?.name,
+    endedAt: state.updatedAt,
+    turnCount: state.turnCount,
+    durationSec: Math.max(1, Math.floor((state.updatedAt - state.createdAt) / 1000)),
+    totalEvents: state.history.length,
+    finalSwing: finalSwingMessage(state.history),
+    players,
+    recentEvents: state.history.slice(-6).reverse(),
+  };
+}

--- a/src/test/app.test.tsx
+++ b/src/test/app.test.tsx
@@ -1,14 +1,31 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { GameState } from '../engine';
 import App from '../App';
 
-const { mockedApplyAction, mockedCreateGame, mockedGetNextPrompt, mockedGetLegalActions } = vi.hoisted(() => ({
+const { mockedApplyAction, mockedCreateGame, mockedGetNextPrompt, mockedGetLegalActions, mockedIsGameOver } = vi.hoisted(() => ({
   mockedApplyAction: vi.fn(),
   mockedCreateGame: vi.fn(),
   mockedGetNextPrompt: vi.fn(),
   mockedGetLegalActions: vi.fn(),
+  mockedIsGameOver: vi.fn(),
 }));
+
+function mockMatchMedia(matches: boolean) {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(() => false),
+    })),
+  });
+}
 
 const baseState: GameState = {
   version: 1,
@@ -69,7 +86,8 @@ vi.mock('../engine', () => {
     createGame: mockedCreateGame.mockImplementation(() => clone()),
     getNextPrompt: mockedGetNextPrompt.mockImplementation(() => ({ playerId: 'p1', text: 'Alpha turn', kind: 'main' })),
     getSetCompletionCount: vi.fn(() => 0),
-    isGameOver: vi.fn(() => ({ done: false, winnerId: undefined })),
+    isGameOver: mockedIsGameOver.mockImplementation((state: GameState) =>
+      state.winnerId ? { done: true, winnerId: state.winnerId } : { done: false, winnerId: undefined }),
     getLegalActions: mockedGetLegalActions.mockImplementation(() => [
       {
         label: 'Draw cards',
@@ -101,8 +119,12 @@ describe('App', () => {
     mockedCreateGame.mockReset();
     mockedGetNextPrompt.mockReset();
     mockedGetLegalActions.mockReset();
+    mockedIsGameOver.mockReset();
+    mockMatchMedia(false);
     mockedCreateGame.mockImplementation(() => structuredClone(baseState));
     mockedGetNextPrompt.mockImplementation(() => ({ playerId: 'p1', text: 'Alpha turn', kind: 'main' }));
+    mockedIsGameOver.mockImplementation((state: GameState) =>
+      state.winnerId ? { done: true, winnerId: state.winnerId } : { done: false, winnerId: undefined });
     mockedGetLegalActions.mockImplementation(() => [
       {
         label: 'Draw cards',
@@ -288,5 +310,114 @@ describe('App', () => {
       targetPlayerId: 'p2',
       color: 'green',
     });
+  });
+
+  it('navigates to a dedicated game-over screen and focuses the victory title', async () => {
+    mockedApplyAction.mockImplementationOnce((state: GameState) => ({
+      state: {
+        ...state,
+        winnerId: 'p1',
+        turn: { ...state.turn, phase: 'finished' },
+        updatedAt: state.updatedAt + 10_000,
+        history: [{ timestamp: 100, type: 'action', message: 'Alpha closed the match with a final set.' }],
+      },
+      events: [],
+    }));
+
+    render(<App />);
+
+    fireEvent.click(screen.getByRole('button', { name: /new game/i }));
+    fireEvent.click(screen.getByRole('button', { name: /start match/i }));
+    fireEvent.click(screen.getByRole('button', { name: /reveal turn/i }));
+    fireEvent.click(screen.getByRole('button', { name: /\$1 card/i }));
+
+    const victoryHeading = await screen.findByRole('heading', { name: /alpha wins!/i });
+    expect(victoryHeading).toBeInTheDocument();
+    expect(screen.queryByRole('heading', { name: /game table/i })).not.toBeInTheDocument();
+    await waitFor(() => {
+      expect(document.activeElement).toBe(victoryHeading);
+    });
+  });
+
+  it('starts a rematch with the same players from the post-game screen', async () => {
+    mockedApplyAction.mockImplementationOnce((state: GameState) => ({
+      state: {
+        ...state,
+        winnerId: 'p1',
+        turn: { ...state.turn, phase: 'finished' },
+        updatedAt: state.updatedAt + 4_000,
+        history: [{ timestamp: 100, type: 'action', message: 'Alpha finished the game.' }],
+      },
+      events: [],
+    }));
+
+    render(<App />);
+
+    fireEvent.click(screen.getByRole('button', { name: /new game/i }));
+    fireEvent.click(screen.getByRole('button', { name: /start match/i }));
+    fireEvent.click(screen.getByRole('button', { name: /reveal turn/i }));
+    fireEvent.click(screen.getByRole('button', { name: /\$1 card/i }));
+
+    await screen.findByRole('button', { name: /play rematch/i });
+    fireEvent.click(screen.getByRole('button', { name: /play rematch/i }));
+
+    expect(mockedCreateGame).toHaveBeenLastCalledWith({
+      players: [
+        { id: 'p1', name: 'Alpha' },
+        { id: 'p2', name: 'Beta' },
+      ],
+      deckVersion: 'v1',
+    });
+    expect(screen.getByRole('heading', { name: /game table/i })).toBeInTheDocument();
+  });
+
+  it('routes to stats from the post-game screen', async () => {
+    mockedApplyAction.mockImplementationOnce((state: GameState) => ({
+      state: {
+        ...state,
+        winnerId: 'p1',
+        turn: { ...state.turn, phase: 'finished' },
+        updatedAt: state.updatedAt + 5_000,
+        history: [{ timestamp: 100, type: 'action', message: 'Alpha won the game.' }],
+      },
+      events: [],
+    }));
+
+    render(<App />);
+
+    fireEvent.click(screen.getByRole('button', { name: /new game/i }));
+    fireEvent.click(screen.getByRole('button', { name: /start match/i }));
+    fireEvent.click(screen.getByRole('button', { name: /reveal turn/i }));
+    fireEvent.click(screen.getByRole('button', { name: /\$1 card/i }));
+
+    await screen.findByRole('button', { name: /view stats/i });
+    fireEvent.click(screen.getByRole('button', { name: /view stats/i }));
+
+    expect(screen.getByRole('heading', { name: /stats & history/i })).toBeInTheDocument();
+  });
+
+  it('disables celebration visuals when reduced motion is preferred', async () => {
+    mockMatchMedia(true);
+    mockedApplyAction.mockImplementationOnce((state: GameState) => ({
+      state: {
+        ...state,
+        winnerId: 'p1',
+        turn: { ...state.turn, phase: 'finished' },
+        updatedAt: state.updatedAt + 6_000,
+        history: [{ timestamp: 100, type: 'action', message: 'Alpha won quickly.' }],
+      },
+      events: [],
+    }));
+
+    const { container } = render(<App />);
+
+    fireEvent.click(screen.getByRole('button', { name: /new game/i }));
+    fireEvent.click(screen.getByRole('button', { name: /start match/i }));
+    fireEvent.click(screen.getByRole('button', { name: /reveal turn/i }));
+    fireEvent.click(screen.getByRole('button', { name: /\$1 card/i }));
+
+    await screen.findByRole('heading', { name: /alpha wins!/i });
+    expect(container.querySelector('.confetti-dot')).toBeNull();
+    expect(screen.getByText(/system reduced-motion preference is enabled/i)).toBeInTheDocument();
   });
 });

--- a/src/test/post-game.test.ts
+++ b/src/test/post-game.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from 'vitest';
+import type { PropertyColor } from '../cards/catalog';
+import type { GameEvent, GameState, PlayerState } from '../engine';
+import type { LifetimeStatsV1 } from '../stats';
+import { buildPostGameSummary } from '../stats';
+
+function emptyProperties(): PlayerState['properties'] {
+  return {
+    brown: [],
+    light_blue: [],
+    pink: [],
+    orange: [],
+    red: [],
+    yellow: [],
+    green: [],
+    dark_blue: [],
+    railroad: [],
+    utility: [],
+  };
+}
+
+function withProperty(player: PlayerState, color: PropertyColor, cardId: string): PlayerState {
+  return {
+    ...player,
+    properties: {
+      ...player.properties,
+      [color]: [...player.properties[color], { cardId, assignedColor: color }],
+    },
+  };
+}
+
+function createPlayer(id: string, name: string): PlayerState {
+  return {
+    id,
+    name,
+    hand: [],
+    bank: [],
+    properties: emptyProperties(),
+  };
+}
+
+function createState(players: PlayerState[], history: GameEvent[], winnerId?: string): GameState {
+  return {
+    version: 1,
+    createdAt: 1_000,
+    updatedAt: 13_000,
+    deckVersion: 'v1',
+    players,
+    drawPile: [],
+    discardPile: [],
+    currentPlayerIndex: 0,
+    turn: { phase: 'finished', playsUsed: 0, doubleRentMultiplier: 1 },
+    pending: null,
+    history,
+    winnerId,
+    turnCount: 14,
+  };
+}
+
+describe('buildPostGameSummary', () => {
+  it('extracts winner and aggregate metrics', () => {
+    const p1 = withProperty(withProperty(withProperty(createPlayer('p1', 'Alpha'), 'brown', 'brown_1#a1'), 'brown', 'brown_1#a2'), 'dark_blue', 'dark_blue_1#a3');
+    const p2 = withProperty(createPlayer('p2', 'Beta'), 'brown', 'brown_1#b1');
+    p1.bank = ['money_5#a4'];
+    p1.hand = ['money_1#a5'];
+    p2.bank = ['money_2#b2'];
+    p2.hand = ['money_1#b3', 'money_1#b4'];
+
+    const history: GameEvent[] = [
+      { timestamp: 10_000, type: 'draw', message: 'Alpha drew 2 cards.' },
+      { timestamp: 11_500, type: 'action', message: 'Alpha played Rent.' },
+      { timestamp: 12_000, type: 'rent_target', message: 'Alpha charged Beta $3 rent.' },
+    ];
+
+    const lifetime: LifetimeStatsV1 = {
+      version: 1,
+      players: {
+        Alpha: {
+          name: 'Alpha',
+          gamesPlayed: 9,
+          wins: 4,
+          totalTurns: 0,
+          totalDurationSec: 0,
+          actionsByType: {},
+        },
+      },
+    };
+
+    const summary = buildPostGameSummary(createState([p1, p2], history, 'p1'), lifetime);
+
+    expect(summary.winnerId).toBe('p1');
+    expect(summary.winnerName).toBe('Alpha');
+    expect(summary.durationSec).toBe(12);
+    expect(summary.turnCount).toBe(14);
+    expect(summary.totalEvents).toBe(3);
+    expect(summary.players[0].name).toBe('Alpha');
+    expect(summary.players[0].rank).toBe(1);
+    expect(summary.players[0].lifetimeWins).toBe(4);
+    expect(summary.recentEvents).toHaveLength(3);
+    expect(summary.recentEvents[0].message).toBe('Alpha charged Beta $3 rent.');
+  });
+
+  it('ranks players by sets, bank, property count, then hand count', () => {
+    let p1 = createPlayer('p1', 'Alpha');
+    let p2 = createPlayer('p2', 'Beta');
+    let p3 = createPlayer('p3', 'Gamma');
+
+    p1 = withProperty(withProperty(withProperty(withProperty(withProperty(withProperty(withProperty(p1, 'brown', 'brown_1#a1'), 'brown', 'brown_1#a2'), 'light_blue', 'light_blue_1#a3'), 'light_blue', 'light_blue_1#a4'), 'light_blue', 'light_blue_1#a5'), 'dark_blue', 'dark_blue_1#a6'), 'dark_blue', 'dark_blue_1#a7');
+    p2 = withProperty(withProperty(withProperty(withProperty(p2, 'brown', 'brown_1#b1'), 'brown', 'brown_1#b2'), 'dark_blue', 'dark_blue_1#b3'), 'dark_blue', 'dark_blue_1#b4');
+    p3 = withProperty(withProperty(withProperty(withProperty(p3, 'brown', 'brown_1#c1'), 'brown', 'brown_1#c2'), 'dark_blue', 'dark_blue_1#c3'), 'dark_blue', 'dark_blue_1#c4');
+
+    p2.bank = ['money_5#b5'];
+    p3.bank = ['money_5#c5'];
+    p2.hand = ['money_1#b6', 'money_2#b7', 'money_1#b8'];
+    p3.hand = ['money_1#c6'];
+
+    const summary = buildPostGameSummary(createState([p1, p2, p3], [], 'p1'), { version: 1, players: {} });
+    expect(summary.players.map((player) => player.playerId)).toEqual(['p1', 'p3', 'p2']);
+  });
+
+  it('uses the last impactful event as final swing highlight', () => {
+    const p1 = createPlayer('p1', 'Alpha');
+    const p2 = createPlayer('p2', 'Beta');
+    const history: GameEvent[] = [
+      { timestamp: 10_000, type: 'draw', message: 'Alpha drew cards.' },
+      { timestamp: 10_200, type: 'turn_passed', message: 'Alpha ended turn.' },
+      { timestamp: 10_500, type: 'action', message: 'Beta played Debt Collector.' },
+      { timestamp: 10_900, type: 'pay', message: 'Alpha paid Beta $5.' },
+      { timestamp: 11_000, type: 'turn_passed', message: 'Beta ended turn.' },
+    ];
+
+    const summary = buildPostGameSummary(createState([p1, p2], history, 'p2'), { version: 1, players: {} });
+    expect(summary.finalSwing).toBe('Alpha paid Beta $5.');
+  });
+});


### PR DESCRIPTION
Summary
- Added a dedicated `game_over` screen state, computed post-game summary model, and persistence-aware transition so the app jumps straight to a victory view once a match ends (`src/App.tsx`, `src/stats/postGame.ts`).
- Built new UI components (hero, KPI strip, standings, highlights, actions) plus accessible focus handling, celebration effects, and reduced-motion support plus styles for the post-game layout (`src/App.tsx`, `src/App.css`).
- Extended test coverage to verify summary modeling, navigation to the post-match screen, and action behaviors, and wired the new stats module into the existing test suite (`src/test/app.test.tsx`, `src/test/post-game.test.ts`).
Testing
- Not run (not requested)