### PR TITLE
Adjust card layout spacing and UI theme polish

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,11 @@ This project focuses on local, pass-and-play gameplay with a rules engine, persi
 - Winner detection at 3 complete property sets
 - Undo for reversible plays during the active turn
 - Match history and lifetime win stats
+- Dedicated Settings screen for display options and dev tooling
+- In-match Pause/Resume control with persistent paused state
+- Dev Mode tools to seed or reseed sample stats/history data
+- Responsive hand layout (fan auto-scales and falls back to rail when space is tight)
+- Property cards with rent ladder cells for faster set-to-rent readability
 - Post-game brag image share (clipboard with download fallback)
 - Auto-save + resume via `localStorage`
 
@@ -55,6 +60,17 @@ Open the local URL shown by Vite (usually `http://localhost:5173`).
 - `npm run test` - run tests once
 - `npm run test:watch` - run tests in watch mode
 
+## Settings
+
+Use the `Settings` screen from Home (or the in-game top bar) to control:
+
+- Reduced celebration effects
+- Text scale (`normal` / `large`)
+- Table density (`cozy` / `compact`)
+- Dev Mode toggle and sample data reseed tools
+
+When a live match is open, the top bar includes `Pause` / `Resume`. Paused state is persisted, so reopening a saved match restores the paused overlay until resumed.
+
 ## Project Structure
 
 ```text
@@ -85,6 +101,7 @@ Game state and stats are stored in browser `localStorage` under versioned keys:
 - `monopolyDeal.matchHistory.v1`
 - `monopolyDeal.lifetimeStats.v1`
 - `monopolyDeal.growthMetrics.v1`
+- `monopolyDeal.uiPreferences.v1`
 
 ## Current Scope
 

--- a/docs/LLM_AGENT_GUIDE.md
+++ b/docs/LLM_AGENT_GUIDE.md
@@ -10,12 +10,12 @@ Purpose: give coding agents enough context to make correct, low-regression chang
 - `src/cards/`
   - Card catalog, set sizes, rent scales, display helpers.
 - `src/persistence/`
-  - `localStorage` read/write wrappers for active game and stats.
+  - `localStorage` read/write wrappers for active game, stats, and UI preferences.
 - `src/stats/`
-  - Match record creation and lifetime aggregation.
+  - Match record creation, lifetime aggregation, and dev fixture data.
 - `src/ui/` + `src/App.tsx`
   - `App.tsx` owns state/actions and passes typed props to screen containers.
-  - `src/ui/screens/` contains home/setup/game/stats/post-game screen composition.
+  - `src/ui/screens/` contains home/setup/game/stats/settings/post-game screen composition.
   - `src/ui/layout/` contains shared shell/top bar/action rail primitives.
   - `src/ui/theme/` contains tokenized CSS split by base/components/screens.
 
@@ -111,7 +111,8 @@ Do not model multiple simultaneous pending effects.
 ## Known Hotspots
 
 - `src/engine/game.ts` is large; regressions are likely when changing shared helpers.
-- `src/App.tsx` coordinates many UI states (chooser, payment selection, pass-and-play shield, undo snapshots).
+- `src/App.tsx` coordinates many UI states (chooser, payment selection, pass-and-play shield, pause state, settings routing, undo snapshots).
+- Card rendering/fit is split between `src/ui/components/CardView.tsx`, `src/ui/components/HandFan.tsx`, and `src/ui/theme/components/cards.css`.
 - Rent/double-rent/counter interactions are edge-case heavy.
 
 ## Recommended Agent Prompt Template
@@ -145,5 +146,6 @@ Validation:
 - Save/load: `src/persistence/storage.ts`
 - Match/lifetime models: `src/stats/types.ts`
 - Match aggregation: `src/stats/records.ts`
+- Dev fixture data: `src/stats/devFixture.ts`
 - Main app orchestration: `src/App.tsx`
 - Tests: `src/test/engine.test.ts`, `src/test/app.test.tsx`, `src/test/card-ui.test.tsx`

--- a/src/App.css
+++ b/src/App.css
@@ -10,3 +10,4 @@
 @import './ui/theme/screens/game.css';
 @import './ui/theme/screens/postgame.css';
 @import './ui/theme/screens/stats.css';
+@import './ui/theme/screens/settings.css';

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -27,23 +27,27 @@ import {
 import {
   applyMatchToLifetime,
   buildMatchRecord,
+  createDevStatsFixture,
   buildPostGameSummary,
   type LifetimeStatsV1,
   type MatchRecordV1,
   type PostGameSummary,
 } from './stats';
-import { PlayChooser, type ActionVariantView } from './ui/components/PlayChooser';
+import type { ActionVariantView } from './ui/components/PlayChooser';
 import { GameShell } from './ui/layout/GameShell';
 import { GameTableScreen } from './ui/screens/GameTableScreen';
 import { HomeScreen } from './ui/screens/HomeScreen';
 import { PostGameScreen } from './ui/screens/PostGameScreen';
+import { SettingsScreen } from './ui/screens/SettingsScreen';
 import { SetupScreen } from './ui/screens/SetupScreen';
 import { StatsScreen } from './ui/screens/StatsScreen';
 import { generatePostGameSharePng, postGameShareFilename } from './ui/share/postGameShare';
 import type { SetupViewModel, ShareStatus } from './ui/types';
 import './App.css';
 
-type Screen = 'home' | 'setup' | 'game' | 'stats' | 'game_over';
+type Screen = 'home' | 'setup' | 'game' | 'stats' | 'settings' | 'game_over';
+type SettingsBackScreen = 'home' | 'game';
+type DevSeedStatus = 'seeded' | 'already-populated' | 'reseeded' | null;
 
 interface CardActionVariant extends ActionVariantView {
   action: Action;
@@ -108,8 +112,13 @@ function formatDuration(seconds: number): string {
   return `${hours}h ${remainingMinutes}m`;
 }
 
+function gameIdentity(game: GameState): string {
+  return `${game.createdAt}`;
+}
+
 function App() {
   const [screen, setScreen] = useState<Screen>('home');
+  const [settingsBackScreen, setSettingsBackScreen] = useState<SettingsBackScreen>('home');
   const [game, setGame] = useState<GameState | null>(null);
   const [postGameSummary, setPostGameSummary] = useState<PostGameSummary | null>(null);
   const [setup, setSetup] = useState<SetupViewModel>(initialSetup);
@@ -126,8 +135,10 @@ function App() {
   const [shareStatus, setShareStatus] = useState<ShareStatus>(null);
   const [turnSnapshots, setTurnSnapshots] = useState<GameState[]>([]);
   const [uiPreferences, setUiPreferences] = useState<UiPreferencesV1>(() => loadUiPreferences());
+  const [devSeedStatus, setDevSeedStatus] = useState<DevSeedStatus>(null);
   const postGameTitleRef = useRef<HTMLHeadingElement | null>(null);
   const finalizedMatchRef = useRef<string | null>(null);
+  const devAutoSeedAttemptedRef = useRef(false);
 
   useEffect(() => {
     if (!game || isGameOver(game).done) return;
@@ -166,7 +177,31 @@ function App() {
     setShareStatus(null);
   }, [postGameSummary?.endedAt, screen]);
 
+  const applyDevFixture = useCallback((status: Exclude<DevSeedStatus, 'already-populated' | null>) => {
+    const fixture = createDevStatsFixture('medium');
+    const nextHistory = structuredClone(fixture.history);
+    const nextLifetime = structuredClone(fixture.lifetime);
+    saveMatchHistory(nextHistory);
+    saveLifetimeStats(nextLifetime);
+    setHistory(nextHistory);
+    setLifetime(nextLifetime);
+    setDevSeedStatus(status);
+  }, []);
+
+  useEffect(() => {
+    if (!uiPreferences.devModeEnabled) {
+      devAutoSeedAttemptedRef.current = false;
+      return;
+    }
+    if (devAutoSeedAttemptedRef.current) return;
+    devAutoSeedAttemptedRef.current = true;
+    if (history.length > 0) return;
+    applyDevFixture('seeded');
+  }, [applyDevFixture, history.length, uiPreferences.devModeEnabled]);
+
   const prompt = useMemo(() => (game ? getNextPrompt(game) : null), [game]);
+  const currentGameId = game ? gameIdentity(game) : null;
+  const isPaused = Boolean(game && uiPreferences.gamePaused && uiPreferences.pausedGameId === currentGameId);
   const reduceCelebrationEffects = uiPreferences.reducedEffects;
   const celebrationEnabled = Boolean(postGameSummary && !prefersReducedMotion && !reduceCelebrationEffects);
 
@@ -294,6 +329,53 @@ function App() {
     ? selectedPaymentCards.length > 0 && (selectedPaymentTotal >= pendingPayment.amount || totalPayableValue < pendingPayment.amount)
     : false;
 
+  const openSettings = useCallback((backScreen: SettingsBackScreen) => {
+    setSettingsBackScreen(backScreen);
+    setScreen('settings');
+    setError(null);
+  }, []);
+
+  const closeSettings = useCallback(() => {
+    if (settingsBackScreen === 'game' && game) {
+      setScreen('game');
+      return;
+    }
+    setScreen('home');
+  }, [game, settingsBackScreen]);
+
+  const togglePause = useCallback(() => {
+    if (!currentGameId) return;
+    setUiPreferences((prev) => {
+      if (prev.gamePaused && prev.pausedGameId === currentGameId) {
+        return { ...prev, gamePaused: false, pausedGameId: null };
+      }
+      return { ...prev, gamePaused: true, pausedGameId: currentGameId };
+    });
+    setChooser(null);
+    setSelectedCardId(null);
+    setSelectedPaymentCards([]);
+    setError(null);
+  }, [currentGameId]);
+
+  const onToggleDevMode = useCallback((enabled: boolean) => {
+    setUiPreferences((prev) => ({ ...prev, devModeEnabled: enabled }));
+    if (!enabled) {
+      setDevSeedStatus(null);
+      devAutoSeedAttemptedRef.current = false;
+      return;
+    }
+    devAutoSeedAttemptedRef.current = true;
+    if (history.length > 0) {
+      setDevSeedStatus('already-populated');
+      return;
+    }
+    applyDevFixture('seeded');
+  }, [applyDevFixture, history.length]);
+
+  const onReseedDevData = useCallback(() => {
+    applyDevFixture('reseeded');
+  }, [applyDevFixture]);
+
   const openGame = useCallback((nextGame: GameState) => {
     finalizedMatchRef.current = null;
     setGame(nextGame);
@@ -309,6 +391,7 @@ function App() {
 
   const startGameWithPlayers = useCallback((players: PlayerConfig[]) => {
     const nextGame = createGame({ players, deckVersion: 'v1' });
+    setUiPreferences((prev) => ({ ...prev, gamePaused: false, pausedGameId: null }));
     openGame(nextGame);
   }, [openGame]);
 
@@ -363,7 +446,7 @@ function App() {
   };
 
   const runAction = (action: Action) => {
-    if (!game) return;
+    if (!game || isPaused) return;
     const shouldSnapshot = isReversibleActionType(action.type) && prompt?.playerId === action.playerId;
     const snapshotBeforeAction = shouldSnapshot ? structuredClone(game) : null;
     const result = applyAction(game, action);
@@ -391,6 +474,7 @@ function App() {
   };
 
   const undoLastPlay = () => {
+    if (isPaused) return;
     if (turnSnapshots.length === 0) return;
     const previousState = turnSnapshots[turnSnapshots.length - 1];
     setGame(previousState);
@@ -402,6 +486,7 @@ function App() {
   };
 
   const resetTurnPlays = () => {
+    if (isPaused) return;
     if (turnSnapshots.length === 0) return;
     const firstState = turnSnapshots[0];
     setGame(firstState);
@@ -413,6 +498,7 @@ function App() {
   };
 
   const handleCardClick = (cardId: string) => {
+    if (isPaused) return;
     if (!game || !prompt) return;
     if (isGameOver(game).done) return;
     if (revealedPlayerId !== prompt.playerId) return;
@@ -434,11 +520,13 @@ function App() {
   };
 
   const handlePaymentCardToggle = (cardId: string) => {
+    if (isPaused) return;
     if (!pendingPayment || !pendingPaymentCardIds.includes(cardId)) return;
     setSelectedPaymentCards((prev) => (prev.includes(cardId) ? prev.filter((id) => id !== cardId) : [...prev, cardId]));
   };
 
   const submitSelectedPayment = () => {
+    if (isPaused) return;
     if (!pendingPayment || !paymentCanSubmit) return;
     runAction({
       type: 'pay_request',
@@ -473,6 +561,7 @@ function App() {
 
   const goHome = useCallback(() => {
     clearActiveGame();
+    setUiPreferences((prev) => ({ ...prev, gamePaused: false, pausedGameId: null }));
     setGame(null);
     setPostGameSummary(null);
     setScreen('home');
@@ -553,6 +642,7 @@ function App() {
           onNewGame={() => setScreen('setup')}
           onResumeGame={resumeGame}
           onOpenStats={() => setScreen('stats')}
+          onOpenSettings={() => openSettings('home')}
         />
       ) : null}
 
@@ -576,6 +666,7 @@ function App() {
         <GameTableScreen
           game={game}
           prompt={prompt}
+          isPaused={isPaused}
           legalActions={legalActions}
           contextualActions={contextualActions}
           revealedPlayerId={revealedPlayerId}
@@ -594,7 +685,12 @@ function App() {
           turnSnapshotsCount={turnSnapshots.length}
           showDebugActions={showDebugActions}
           actionDetailText={actionDetailText}
-          onToggleDebugActions={() => setShowDebugActions((prev) => !prev)}
+          onPauseToggle={togglePause}
+          onOpenSettings={() => openSettings('game')}
+          onToggleDebugActions={() => {
+            if (isPaused) return;
+            setShowDebugActions((prev) => !prev);
+          }}
           onRunAction={runAction}
           onCardClick={handleCardClick}
           onPaymentCardToggle={handlePaymentCardToggle}
@@ -602,16 +698,32 @@ function App() {
           onUndoLastPlay={undoLastPlay}
           onResetTurnPlays={resetTurnPlays}
           onCloseChooser={() => {
+            if (isPaused) return;
             setChooser(null);
             setSelectedCardId(null);
           }}
-          onRevealTurn={() => setRevealedPlayerId(prompt.playerId)}
+          onRevealTurn={() => {
+            if (isPaused) return;
+            setRevealedPlayerId(prompt.playerId);
+          }}
           onNavigateHome={() => setScreen('home')}
-          onEndMatch={goHome}
         />
       ) : null}
 
       {screen === 'stats' ? <StatsScreen history={history} lifetime={lifetime} onBack={() => setScreen('home')} /> : null}
+
+      {screen === 'settings' ? (
+        <SettingsScreen
+          uiPreferences={uiPreferences}
+          devSeedStatus={devSeedStatus}
+          onToggleReducedEffects={(enabled) => setUiPreferences((prev) => ({ ...prev, reducedEffects: enabled }))}
+          onChangeTextScale={(value) => setUiPreferences((prev) => ({ ...prev, textScale: value }))}
+          onChangeTableDensity={(value) => setUiPreferences((prev) => ({ ...prev, tableDensity: value }))}
+          onToggleDevMode={onToggleDevMode}
+          onReseedDevData={onReseedDevData}
+          onBack={closeSettings}
+        />
+      ) : null}
 
       {screen === 'game_over' && postGameSummary ? (
         <PostGameScreen

--- a/src/persistence/storage.ts
+++ b/src/persistence/storage.ts
@@ -18,6 +18,9 @@ export interface UiPreferencesV1 {
   reducedEffects: boolean;
   tableDensity: 'cozy' | 'compact';
   textScale: 'normal' | 'large';
+  devModeEnabled: boolean;
+  gamePaused: boolean;
+  pausedGameId: string | null;
 }
 
 export function saveActiveGame(state: GameState): void {
@@ -129,6 +132,9 @@ function defaultUiPreferences(): UiPreferencesV1 {
     reducedEffects: false,
     tableDensity: 'cozy',
     textScale: 'normal',
+    devModeEnabled: false,
+    gamePaused: false,
+    pausedGameId: null,
   };
 }
 
@@ -145,6 +151,9 @@ export function loadUiPreferences(): UiPreferencesV1 {
       reducedEffects: Boolean(parsed.reducedEffects),
       tableDensity: density,
       textScale,
+      devModeEnabled: Boolean(parsed.devModeEnabled),
+      gamePaused: Boolean(parsed.gamePaused),
+      pausedGameId: typeof parsed.pausedGameId === 'string' ? parsed.pausedGameId : null,
     };
   } catch {
     return defaultUiPreferences();

--- a/src/stats/devFixture.ts
+++ b/src/stats/devFixture.ts
@@ -1,0 +1,83 @@
+import type { LifetimeStatsV1, MatchRecordV1 } from './types';
+
+export interface DevStatsFixture {
+  history: MatchRecordV1[];
+  lifetime: LifetimeStatsV1;
+}
+
+function mediumFixture(): DevStatsFixture {
+  const history: MatchRecordV1[] = [
+    {
+      id: 'm-3',
+      startedAt: 1_700_000_000_000,
+      endedAt: 1_700_000_060_000,
+      players: ['Alpha', 'Beta'],
+      winnerId: 'p1',
+      winnerName: 'Alpha',
+      turnCount: 16,
+      durationSec: 600,
+      actionsByType: { action: 8, pay: 3, draw: 5 },
+    },
+    {
+      id: 'm-2',
+      startedAt: 1_700_000_100_000,
+      endedAt: 1_700_000_130_000,
+      players: ['Alpha', 'Beta', 'Gamma'],
+      winnerId: 'p2',
+      winnerName: 'Beta',
+      turnCount: 12,
+      durationSec: 300,
+      actionsByType: { action: 7, pay: 2, draw: 4 },
+    },
+    {
+      id: 'm-1',
+      startedAt: 1_700_000_200_000,
+      endedAt: 1_700_000_270_000,
+      players: ['Alpha', 'Gamma'],
+      winnerId: 'p1',
+      winnerName: 'Alpha',
+      turnCount: 24,
+      durationSec: 700,
+      actionsByType: { action: 11, pay: 4, draw: 6 },
+    },
+  ];
+
+  const lifetime: LifetimeStatsV1 = {
+    version: 1,
+    players: {
+      Alpha: {
+        name: 'Alpha',
+        gamesPlayed: 3,
+        wins: 2,
+        totalTurns: 52,
+        totalDurationSec: 1600,
+        actionsByType: { action: 26, pay: 9, draw: 15 },
+      },
+      Beta: {
+        name: 'Beta',
+        gamesPlayed: 2,
+        wins: 1,
+        totalTurns: 28,
+        totalDurationSec: 900,
+        actionsByType: { action: 15, pay: 5, draw: 8 },
+      },
+      Gamma: {
+        name: 'Gamma',
+        gamesPlayed: 2,
+        wins: 0,
+        totalTurns: 36,
+        totalDurationSec: 1000,
+        actionsByType: { action: 18, pay: 6, draw: 10 },
+      },
+    },
+  };
+
+  return { history, lifetime };
+}
+
+export function createDevStatsFixture(kind: 'medium' = 'medium'): DevStatsFixture {
+  if (kind === 'medium') {
+    return mediumFixture();
+  }
+  return mediumFixture();
+}

--- a/src/stats/index.ts
+++ b/src/stats/index.ts
@@ -2,3 +2,4 @@ export * from './types';
 export * from './records';
 export * from './dashboard';
 export * from './postGame';
+export * from './devFixture';

--- a/src/test/app.test.tsx
+++ b/src/test/app.test.tsx
@@ -1,6 +1,7 @@
 import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { GameState } from '../engine';
+import { createDevStatsFixture } from '../stats';
 import App from '../App';
 import { createStatsFixture } from './fixtures/statsFixtures';
 
@@ -85,9 +86,11 @@ const baseState: GameState = {
   turnCount: 1,
 };
 
+const ACTIVE_GAME_KEY = 'monopolyDeal.activeGame.v1';
 const MATCH_HISTORY_KEY = 'monopolyDeal.matchHistory.v1';
 const LIFETIME_STATS_KEY = 'monopolyDeal.lifetimeStats.v1';
 const GROWTH_METRICS_KEY = 'monopolyDeal.growthMetrics.v1';
+const UI_PREFERENCES_KEY = 'monopolyDeal.uiPreferences.v1';
 
 vi.mock('../engine', () => {
   const clone = () => structuredClone(baseState);
@@ -395,6 +398,188 @@ describe('App', () => {
     const ascMatchRows = within(matchSection as HTMLElement).getAllByRole('row');
     const firstMatchCells = ascMatchRows[1].querySelectorAll('td');
     expect(firstMatchCells[3]?.textContent).toBe('16');
+  });
+
+  it('seeds stats and history when dev mode is enabled and local data is empty', async () => {
+    const fixture = createDevStatsFixture('medium');
+
+    render(<App />);
+    fireEvent.click(screen.getByRole('button', { name: /^settings$/i }));
+    fireEvent.click(screen.getByRole('checkbox', { name: /dev mode/i }));
+
+    expect(JSON.parse(localStorage.getItem(MATCH_HISTORY_KEY) ?? '[]')).toEqual(fixture.history);
+    expect(JSON.parse(localStorage.getItem(LIFETIME_STATS_KEY) ?? '{}')).toEqual(fixture.lifetime);
+    expect(screen.getByText(/seeded medium sample stats and match history/i)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /back/i }));
+    fireEvent.click(screen.getByRole('button', { name: /stats & history/i }));
+
+    expect(await screen.findByRole('heading', { name: /stats & history/i })).toBeInTheDocument();
+    expect(screen.getByText(/total matches/i)).toBeInTheDocument();
+  });
+
+  it('does not overwrite existing stats/history when enabling dev mode', () => {
+    const existingHistory = [
+      {
+        id: 'existing-1',
+        startedAt: 1,
+        endedAt: 11,
+        players: ['Existing'],
+        winnerId: 'p1',
+        winnerName: 'Existing',
+        turnCount: 5,
+        durationSec: 10,
+        actionsByType: { action: 3 },
+      },
+    ];
+    const existingLifetime = {
+      version: 1,
+      players: {
+        Existing: {
+          name: 'Existing',
+          gamesPlayed: 1,
+          wins: 1,
+          totalTurns: 5,
+          totalDurationSec: 10,
+          actionsByType: { action: 3 },
+        },
+      },
+    };
+    localStorage.setItem(MATCH_HISTORY_KEY, JSON.stringify(existingHistory));
+    localStorage.setItem(LIFETIME_STATS_KEY, JSON.stringify(existingLifetime));
+
+    render(<App />);
+    fireEvent.click(screen.getByRole('button', { name: /^settings$/i }));
+    fireEvent.click(screen.getByRole('checkbox', { name: /dev mode/i }));
+
+    expect(JSON.parse(localStorage.getItem(MATCH_HISTORY_KEY) ?? '[]')).toEqual(existingHistory);
+    expect(JSON.parse(localStorage.getItem(LIFETIME_STATS_KEY) ?? '{}')).toEqual(existingLifetime);
+    expect(screen.getByText(/skipped auto-seed because match history already contains data/i)).toBeInTheDocument();
+  });
+
+  it('reseeds stats/history from settings when requested', () => {
+    const fixture = createDevStatsFixture('medium');
+    localStorage.setItem(
+      MATCH_HISTORY_KEY,
+      JSON.stringify([
+        {
+          id: 'old-1',
+          startedAt: 5,
+          endedAt: 6,
+          players: ['Old'],
+          turnCount: 1,
+          durationSec: 1,
+          actionsByType: {},
+        },
+      ]),
+    );
+    localStorage.setItem(
+      LIFETIME_STATS_KEY,
+      JSON.stringify({
+        version: 1,
+        players: {},
+      }),
+    );
+
+    render(<App />);
+    fireEvent.click(screen.getByRole('button', { name: /^settings$/i }));
+    fireEvent.click(screen.getByRole('checkbox', { name: /dev mode/i }));
+    fireEvent.click(screen.getByRole('button', { name: /reseed stats & history/i }));
+
+    expect(JSON.parse(localStorage.getItem(MATCH_HISTORY_KEY) ?? '[]')).toEqual(fixture.history);
+    expect(JSON.parse(localStorage.getItem(LIFETIME_STATS_KEY) ?? '{}')).toEqual(fixture.lifetime);
+    expect(screen.getByText(/replaced stats and match history with medium sample data/i)).toBeInTheDocument();
+  });
+
+  it('blocks gameplay actions while paused and allows them again after resume', () => {
+    render(<App />);
+
+    fireEvent.click(screen.getByRole('button', { name: /new game/i }));
+    fireEvent.click(screen.getByRole('button', { name: /start match/i }));
+    fireEvent.click(screen.getByRole('button', { name: /reveal turn/i }));
+
+    fireEvent.click(screen.getByRole('button', { name: /^pause$/i }));
+    expect(screen.getByRole('dialog', { name: /game paused/i })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /\$1 card/i }));
+    expect(mockedApplyAction).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole('button', { name: /^resume$/i }));
+    fireEvent.click(screen.getByRole('button', { name: /\$1 card/i }));
+    expect(mockedApplyAction).toHaveBeenCalledWith(expect.anything(), {
+      type: 'play_to_bank',
+      playerId: 'p1',
+      cardId: 'money_1#a1',
+    });
+  });
+
+  it('restores paused state when resuming a saved game after reload', () => {
+    localStorage.setItem(
+      ACTIVE_GAME_KEY,
+      JSON.stringify({
+        version: 1,
+        timestamp: 1,
+        gameState: baseState,
+      }),
+    );
+    localStorage.setItem(
+      UI_PREFERENCES_KEY,
+      JSON.stringify({
+        version: 1,
+        reducedEffects: false,
+        tableDensity: 'cozy',
+        textScale: 'normal',
+        devModeEnabled: false,
+        gamePaused: true,
+        pausedGameId: `${baseState.createdAt}`,
+      }),
+    );
+
+    render(<App />);
+    fireEvent.click(screen.getByRole('button', { name: /resume saved game/i }));
+
+    expect(screen.getByRole('heading', { name: /game table/i })).toBeInTheDocument();
+    expect(screen.getByRole('dialog', { name: /game paused/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /^resume$/i })).toBeInTheDocument();
+  });
+
+  it('does not carry paused state into a new match', () => {
+    render(<App />);
+
+    fireEvent.click(screen.getByRole('button', { name: /new game/i }));
+    fireEvent.click(screen.getByRole('button', { name: /start match/i }));
+    fireEvent.click(screen.getByRole('button', { name: /reveal turn/i }));
+    fireEvent.click(screen.getByRole('button', { name: /^pause$/i }));
+    expect(screen.getByRole('dialog', { name: /game paused/i })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /home/i }));
+    fireEvent.click(screen.getByRole('button', { name: /new game/i }));
+    fireEvent.click(screen.getByRole('button', { name: /start match/i }));
+    fireEvent.click(screen.getByRole('button', { name: /reveal turn/i }));
+
+    expect(screen.queryByRole('dialog', { name: /game paused/i })).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /\$1 card/i }));
+    expect(mockedApplyAction).toHaveBeenCalledWith(expect.anything(), {
+      type: 'play_to_bank',
+      playerId: 'p1',
+      cardId: 'money_1#a1',
+    });
+  });
+
+  it('navigates to settings from both home and game screens', () => {
+    render(<App />);
+
+    fireEvent.click(screen.getByRole('button', { name: /^settings$/i }));
+    expect(screen.getByRole('heading', { name: /^settings$/i })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /back/i }));
+    expect(screen.getByRole('heading', { name: /monopoly deal local/i })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /new game/i }));
+    fireEvent.click(screen.getByRole('button', { name: /start match/i }));
+    expect(screen.getByRole('heading', { name: /game table/i })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /^settings$/i }));
+    expect(screen.getByRole('heading', { name: /^settings$/i })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /back/i }));
+    expect(screen.getByRole('heading', { name: /game table/i })).toBeInTheDocument();
   });
 
   it('navigates to a dedicated game-over screen and focuses the victory title', async () => {

--- a/src/test/card-ui.test.tsx
+++ b/src/test/card-ui.test.tsx
@@ -1,6 +1,7 @@
-import { render, screen } from '@testing-library/react';
-import { describe, expect, it } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
 import { CardView } from '../ui/components/CardView';
+import { HandFan } from '../ui/components/HandFan';
 import { getCardVisualModel } from '../ui/cards';
 
 describe('Card UI', () => {
@@ -18,8 +19,9 @@ describe('Card UI', () => {
     expect(screen.getByRole('button', { name: /debt collector card/i })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /\$5 card/i })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /wild red\/yellow card/i })).toBeInTheDocument();
-    expect(screen.getByText(/set 2/i)).toBeInTheDocument();
-    expect(screen.getByText(/rent \$1\/\$2/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/rent ladder/i)).toBeInTheDocument();
+    expect(screen.getByText(/^rent$/i)).toBeInTheDocument();
+    expect(screen.getByText('$2')).toBeInTheDocument();
   });
 
   it('uses dedicated rent card themes instead of generic action blue', () => {
@@ -59,5 +61,47 @@ describe('Card UI', () => {
       expect(model.themeClass).toBe(testCase.themeClass);
       expect(model.accent).toBe(testCase.accent);
     }
+  });
+
+  it('highlights the full-set rent step for property cards', () => {
+    const { container } = render(<CardView cardId="railroad_1#1" />);
+    const fullSetSteps = container.querySelectorAll('.card-rent-step.is-fullset');
+
+    expect(fullSetSteps.length).toBe(1);
+    expect(fullSetSteps[0]?.textContent).toContain('$4');
+  });
+
+  it('uses auto fit mode for fan/rail hand layout based on available width', async () => {
+    const rectSpy = vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect');
+    const baseRect = { x: 0, y: 0, top: 0, left: 0, right: 0, bottom: 0, width: 0, height: 0, toJSON: () => ({}) };
+    rectSpy.mockImplementation(function mockRect(this: HTMLElement) {
+      if (this.classList?.contains('hand-fan') && this.childElementCount <= 6) {
+        return { ...baseRect, width: 620, right: 620, bottom: 200, height: 200 } as DOMRect;
+      }
+      if (this.classList?.contains('hand-fan')) {
+        return { ...baseRect, width: 260, right: 260, bottom: 200, height: 200 } as DOMRect;
+      }
+      return { ...baseRect } as DOMRect;
+    });
+
+    const cards = ['money_1#a', 'money_2#b', 'money_3#c', 'money_4#d', 'money_5#e', 'money_10#f'];
+    const allPlayable = new Set(cards);
+    const { rerender } = render(
+      <HandFan cards={cards} playableCardIds={allPlayable} selectedCardId={null} onCardClick={() => undefined} interactive fitMode="auto" />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByLabelText(/player hand/i)).toHaveAttribute('data-layout', 'fan');
+    });
+
+    const moreCards = [...cards, 'brown_1#g', 'light_blue_1#h', 'pink_1#i', 'orange_1#j'];
+    rerender(
+      <HandFan cards={moreCards} playableCardIds={new Set(moreCards)} selectedCardId={null} onCardClick={() => undefined} interactive fitMode="auto" />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByLabelText(/player hand/i)).toHaveAttribute('data-layout', 'rail');
+    });
+    rectSpy.mockRestore();
   });
 });

--- a/src/test/fixtures/statsFixtures.ts
+++ b/src/test/fixtures/statsFixtures.ts
@@ -1,78 +1,8 @@
-import type { LifetimeStatsV1, MatchRecordV1 } from '../../stats';
+import { createDevStatsFixture, type LifetimeStatsV1, type MatchRecordV1 } from '../../stats';
 
 export interface StatsFixture {
   history: MatchRecordV1[];
   lifetime: LifetimeStatsV1;
-}
-
-function mediumFixture(): StatsFixture {
-  const history: MatchRecordV1[] = [
-    {
-      id: 'm-3',
-      startedAt: 1_700_000_000_000,
-      endedAt: 1_700_000_060_000,
-      players: ['Alpha', 'Beta'],
-      winnerId: 'p1',
-      winnerName: 'Alpha',
-      turnCount: 16,
-      durationSec: 600,
-      actionsByType: { action: 8, pay: 3, draw: 5 },
-    },
-    {
-      id: 'm-2',
-      startedAt: 1_700_000_100_000,
-      endedAt: 1_700_000_130_000,
-      players: ['Alpha', 'Beta', 'Gamma'],
-      winnerId: 'p2',
-      winnerName: 'Beta',
-      turnCount: 12,
-      durationSec: 300,
-      actionsByType: { action: 7, pay: 2, draw: 4 },
-    },
-    {
-      id: 'm-1',
-      startedAt: 1_700_000_200_000,
-      endedAt: 1_700_000_270_000,
-      players: ['Alpha', 'Gamma'],
-      winnerId: 'p1',
-      winnerName: 'Alpha',
-      turnCount: 24,
-      durationSec: 700,
-      actionsByType: { action: 11, pay: 4, draw: 6 },
-    },
-  ];
-
-  const lifetime: LifetimeStatsV1 = {
-    version: 1,
-    players: {
-      Alpha: {
-        name: 'Alpha',
-        gamesPlayed: 3,
-        wins: 2,
-        totalTurns: 52,
-        totalDurationSec: 1600,
-        actionsByType: { action: 26, pay: 9, draw: 15 },
-      },
-      Beta: {
-        name: 'Beta',
-        gamesPlayed: 2,
-        wins: 1,
-        totalTurns: 28,
-        totalDurationSec: 900,
-        actionsByType: { action: 15, pay: 5, draw: 8 },
-      },
-      Gamma: {
-        name: 'Gamma',
-        gamesPlayed: 2,
-        wins: 0,
-        totalTurns: 36,
-        totalDurationSec: 1000,
-        actionsByType: { action: 18, pay: 6, draw: 10 },
-      },
-    },
-  };
-
-  return { history, lifetime };
 }
 
 function edgeFixture(): StatsFixture {
@@ -105,7 +35,7 @@ function edgeFixture(): StatsFixture {
 }
 
 export function createStatsFixture(kind: 'medium' | 'edge' | 'empty' = 'medium'): StatsFixture {
-  if (kind === 'medium') return mediumFixture();
+  if (kind === 'medium') return createDevStatsFixture('medium');
   if (kind === 'edge') return edgeFixture();
   return { history: [], lifetime: { version: 1, players: {} } };
 }

--- a/src/test/storage.test.ts
+++ b/src/test/storage.test.ts
@@ -1,5 +1,11 @@
 import { beforeEach, describe, expect, it } from 'vitest';
-import { incrementGrowthMetric, loadGrowthMetrics, saveGrowthMetrics } from '../persistence/storage';
+import {
+  incrementGrowthMetric,
+  loadGrowthMetrics,
+  loadUiPreferences,
+  saveGrowthMetrics,
+  saveUiPreferences,
+} from '../persistence/storage';
 
 describe('growth metrics storage', () => {
   beforeEach(() => {
@@ -55,5 +61,79 @@ describe('growth metrics storage', () => {
     const next = incrementGrowthMetric('share_image_clicked');
     expect(next.events.share_image_clicked).toBe(1);
     expect(next.events.share_image_success).toBe(0);
+  });
+});
+
+describe('ui preferences storage', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('backfills new preference fields for legacy v1 payloads', () => {
+    localStorage.setItem(
+      'monopolyDeal.uiPreferences.v1',
+      JSON.stringify({
+        version: 1,
+        reducedEffects: true,
+        tableDensity: 'compact',
+        textScale: 'large',
+      }),
+    );
+
+    expect(loadUiPreferences()).toEqual({
+      version: 1,
+      reducedEffects: true,
+      tableDensity: 'compact',
+      textScale: 'large',
+      devModeEnabled: false,
+      gamePaused: false,
+      pausedGameId: null,
+    });
+  });
+
+  it('sanitizes invalid values and falls back to defaults', () => {
+    localStorage.setItem(
+      'monopolyDeal.uiPreferences.v1',
+      JSON.stringify({
+        version: 1,
+        reducedEffects: 'yes',
+        tableDensity: 'spacious',
+        textScale: 'tiny',
+        devModeEnabled: 1,
+        gamePaused: null,
+      }),
+    );
+
+    expect(loadUiPreferences()).toEqual({
+      version: 1,
+      reducedEffects: true,
+      tableDensity: 'cozy',
+      textScale: 'normal',
+      devModeEnabled: true,
+      gamePaused: false,
+      pausedGameId: null,
+    });
+  });
+
+  it('round-trips new preference fields via save/load', () => {
+    saveUiPreferences({
+      version: 1,
+      reducedEffects: false,
+      tableDensity: 'compact',
+      textScale: 'large',
+      devModeEnabled: true,
+      gamePaused: true,
+      pausedGameId: 'game-123',
+    });
+
+    expect(loadUiPreferences()).toEqual({
+      version: 1,
+      reducedEffects: false,
+      tableDensity: 'compact',
+      textScale: 'large',
+      devModeEnabled: true,
+      gamePaused: true,
+      pausedGameId: 'game-123',
+    });
   });
 });

--- a/src/ui/cards.ts
+++ b/src/ui/cards.ts
@@ -1,12 +1,20 @@
-import { getCardDefinition, getRentScale, getSetSize, type CardDefinition, type PropertyColor } from '../cards/catalog';
+import { formatPropertyColor, getCardDefinition, getRentScale, getSetSize, type CardDefinition, type PropertyColor } from '../cards/catalog';
+
+export interface RentStep {
+  setCount: number;
+  rent: number;
+}
 
 export interface CardVisualModel {
   cardId: string;
   title: string;
   subtitle: string;
   valueBadge: string;
+  cardRole: 'money' | 'property' | 'wild' | 'action' | 'building';
+  colorLabel?: string;
+  rentSteps?: RentStep[];
   setSize?: number;
-  rentScale?: number[];
+  actionBadge?: string;
   kindClass: 'money' | 'property' | 'wild' | 'action' | 'building';
   themeClass: string;
   accent: string;
@@ -24,10 +32,35 @@ function titleFromCard(card: CardDefinition): string {
 
 function subtitleFromCard(card: CardDefinition): string {
   if (card.kind === 'money') return 'Money';
-  if (card.kind === 'property') return `${card.color?.replace('_', ' ')} property`;
+  if (card.kind === 'property') return `${formatPropertyColor(card.color!)} Property`;
   if (card.kind === 'wild') return `Wild: ${(card.colors ?? []).map((color) => color.replace('_', ' ')).join(' / ')}`;
   if (card.kind === 'building') return 'Building';
   return 'Action';
+}
+
+function actionBadgeFromCard(card: CardDefinition): string | undefined {
+  if (card.kind === 'action' && card.actionKind) {
+    return card.actionKind.replace('_', ' ').replace(/\b\w/g, (value) => value.toUpperCase());
+  }
+  if (card.kind === 'building' && card.actionKind) {
+    return card.actionKind.replace('_', ' ').replace(/\b\w/g, (value) => value.toUpperCase());
+  }
+  return undefined;
+}
+
+function colorLabelFromCard(card: CardDefinition): string | undefined {
+  if (card.kind === 'property' && card.color) return formatPropertyColor(card.color);
+  if (card.kind === 'wild' && card.colors?.length) return card.colors.map((color) => formatPropertyColor(color)).join(' / ');
+  if (card.kind === 'action' && card.rentMatrix) {
+    const colors = Object.keys(card.rentMatrix) as PropertyColor[];
+    if (colors.length > 0) return colors.map((color) => formatPropertyColor(color)).join(' / ');
+  }
+  return undefined;
+}
+
+function rentStepsFromScale(rentScale: number[] | undefined): RentStep[] | undefined {
+  if (!rentScale || rentScale.length === 0) return undefined;
+  return rentScale.map((rent, index) => ({ setCount: index + 1, rent }));
 }
 
 function themeFromCard(card: CardDefinition): { themeClass: string; accent: string; splitAccent?: string } {
@@ -83,8 +116,11 @@ export function getCardVisualModel(cardId: string): CardVisualModel {
     title: titleFromCard(card),
     subtitle: subtitleFromCard(card),
     valueBadge: `$${card.moneyValue ?? card.value}`,
+    cardRole: card.kind,
+    colorLabel: colorLabelFromCard(card),
+    rentSteps: rentStepsFromScale(rentScale),
     setSize,
-    rentScale,
+    actionBadge: actionBadgeFromCard(card),
     kindClass: card.kind,
     themeClass: theme.themeClass,
     accent: theme.accent,

--- a/src/ui/components/CardView.tsx
+++ b/src/ui/components/CardView.tsx
@@ -10,6 +10,7 @@ interface CardViewProps {
   cardId: string;
   faceUp?: boolean;
   size?: CardSize;
+  context?: 'hand' | 'table';
   variant?: CardVariant;
   elevation?: CardElevation;
   statusTone?: CardStatusTone;
@@ -24,6 +25,7 @@ export function CardView({
   cardId,
   faceUp = true,
   size = 'md',
+  context = 'table',
   variant = 'premium',
   elevation = 'base',
   statusTone = 'neutral',
@@ -48,31 +50,50 @@ export function CardView({
   }
 
   const model = getCardVisualModel(cardId);
-  const metaParts: string[] = [];
-  if (model.setSize) metaParts.push(`Set ${model.setSize}`);
-  if (model.rentScale && model.rentScale.length > 0) {
-    metaParts.push(`Rent $${model.rentScale.join('/$')}`);
-  }
-  const metaText = metaParts.join(' • ');
   const style: CSSProperties = {
     ['--card-accent' as string]: model.accent,
     ['--card-accent-split' as string]: model.splitAccent ?? model.accent,
   };
+  const isProperty = model.cardRole === 'property';
+  const isCompactRent = size === 'sm';
+  const isHandCard = context === 'hand';
+  const shouldShowSubtitle = !(isHandCard && size === 'lg' && (model.cardRole === 'money' || model.cardRole === 'property'));
 
   return (
     <button
       type="button"
-      className={`card-view card-size-${size} card-variant-${variant} card-elevation-${elevation} tone-${statusTone} ${model.themeClass} kind-${model.kindClass} ${interactive ? 'is-interactive' : ''} ${playable ? 'is-playable' : 'is-unplayable'} ${selected ? 'is-selected' : ''}`}
+      className={`card-view card-size-${size} card-context-${context} card-variant-${variant} card-elevation-${elevation} tone-${statusTone} ${model.themeClass} kind-${model.kindClass} role-${model.cardRole} ${interactive ? 'is-interactive' : ''} ${playable ? 'is-playable' : 'is-unplayable'} ${selected ? 'is-selected' : ''}`}
       style={style}
       onClick={onClick}
       disabled={!interactive || !onClick}
       aria-label={`${model.title} card`}
     >
       <span className="card-face">
-        <span className="card-value">{model.valueBadge}</span>
+        <span className="card-head">
+          <span className="card-value">{model.valueBadge}</span>
+          {model.actionBadge ? <span className="card-badge">{model.actionBadge}</span> : null}
+        </span>
         <span className="card-title" title={model.title}>{model.title}</span>
-        <span className="card-subtitle" title={model.subtitle}>{model.subtitle}</span>
-        {metaText ? <span className="card-meta" title={metaText}>{metaText}</span> : null}
+        {shouldShowSubtitle ? <span className="card-subtitle" title={model.subtitle}>{model.subtitle}</span> : null}
+        {model.colorLabel ? <span className="card-color-label">{model.colorLabel}</span> : null}
+
+        {isProperty && model.rentSteps ? (
+          <span className={`card-rent ${isCompactRent ? 'is-compact' : ''}`} aria-label="Rent ladder">
+            <span className="card-rent-label">Rent</span>
+            <span className="card-rent-grid">
+              {model.rentSteps.map((step) => (
+                <span
+                  key={`${model.cardId}-rent-${step.setCount}`}
+                  className={`card-rent-step ${step.setCount === model.setSize ? 'is-fullset' : ''}`}
+                >
+                  <span>{step.setCount}</span>
+                  <span>${step.rent}</span>
+                </span>
+              ))}
+            </span>
+          </span>
+        ) : null}
+
         {annotation ? <span className="card-annotation">{annotation}</span> : null}
       </span>
     </button>

--- a/src/ui/components/HandFan.tsx
+++ b/src/ui/components/HandFan.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useMemo, useRef, useState, type CSSProperties } from 'react';
 import { CardView } from './CardView';
 
 interface HandFanProps {
@@ -6,7 +7,15 @@ interface HandFanProps {
   selectedCardId: string | null;
   onCardClick: (cardId: string) => void;
   interactive: boolean;
-  layout?: 'fan' | 'rail';
+  fitMode?: 'auto' | 'fan' | 'rail';
+}
+
+const MIN_CARD_WIDTH = 88;
+const MAX_CARD_WIDTH = 108;
+const CARD_ASPECT_RATIO = 152 / 108;
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, value));
 }
 
 export function HandFan({
@@ -15,17 +24,91 @@ export function HandFan({
   selectedCardId,
   onCardClick,
   interactive,
-  layout = 'fan',
+  fitMode = 'auto',
 }: HandFanProps) {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const [containerWidth, setContainerWidth] = useState(0);
+
+  useEffect(() => {
+    const element = containerRef.current;
+    if (!element) return;
+
+    const syncWidth = () => {
+      const width = element.getBoundingClientRect().width;
+      setContainerWidth(Math.round(width));
+    };
+
+    syncWidth();
+    const observer = new ResizeObserver(syncWidth);
+    observer.observe(element);
+    return () => observer.disconnect();
+  }, []);
+
+  const fitModel = useMemo(() => {
+    const count = Math.max(cards.length, 1);
+    const baseCardWidth = clamp(MAX_CARD_WIDTH - Math.max(0, count - 7) * 2, MIN_CARD_WIDTH, MAX_CARD_WIDTH);
+    const fanOverlap = clamp(baseCardWidth * 0.3, 16, 30);
+    const visiblePerCard = Math.max(baseCardWidth - fanOverlap, 30);
+    const neededFanWidth = baseCardWidth + (count - 1) * visiblePerCard + 24;
+    const availableWidth = Math.max(containerWidth - 12, 0);
+
+    let resolvedLayout: 'fan' | 'rail';
+    if (fitMode === 'fan') {
+      resolvedLayout = 'fan';
+    } else if (fitMode === 'rail') {
+      resolvedLayout = 'rail';
+    } else {
+      resolvedLayout = neededFanWidth <= availableWidth * 1.03 || count <= 4 ? 'fan' : 'rail';
+    }
+
+    if (resolvedLayout === 'rail') {
+      const targetRailWidth = availableWidth > 0 ? availableWidth * 0.34 : baseCardWidth;
+      const railCardWidth = clamp(Math.round(targetRailWidth), 108, 132);
+      const railGap = clamp(Math.round(railCardWidth * 0.12), 12, 18);
+      return {
+        layout: resolvedLayout,
+        cardWidth: railCardWidth,
+        cardHeight: Math.round(railCardWidth * CARD_ASPECT_RATIO),
+        overlap: 0,
+        railGap,
+        spread: 0,
+      };
+    }
+
+    const scale = availableWidth > 0 ? clamp(availableWidth / Math.max(neededFanWidth, 1), 0.84, 1) : 1;
+    const cardWidth = Math.round(baseCardWidth * scale);
+    const overlap = clamp(fanOverlap * scale, 18, 40);
+    const spread = clamp((34 / Math.max(count, 2)) * scale, 3.2, 10.5);
+    return {
+      layout: resolvedLayout,
+      cardWidth,
+      cardHeight: Math.round(cardWidth * CARD_ASPECT_RATIO),
+      overlap,
+      railGap: 0,
+      spread,
+    };
+  }, [cards.length, containerWidth, fitMode]);
+
   const midpoint = (cards.length - 1) / 2;
-  const spread = Math.max(3.8, Math.min(11, 34 / Math.max(cards.length, 2)));
-  const isRailLayout = layout === 'rail';
+  const isRailLayout = fitModel.layout === 'rail';
+  const style: CSSProperties = {
+    ['--hand-card-w' as string]: `${fitModel.cardWidth}px`,
+    ['--hand-card-h' as string]: `${fitModel.cardHeight}px`,
+    ['--fan-overlap' as string]: `${fitModel.overlap}px`,
+    ['--rail-gap' as string]: `${fitModel.railGap}px`,
+  };
 
   return (
-    <div className={`hand-fan ${isRailLayout ? 'is-rail' : ''}`} aria-label="Player hand">
+    <div
+      ref={containerRef}
+      className={`hand-fan ${isRailLayout ? 'is-rail' : 'is-fan'}`}
+      style={style}
+      aria-label="Player hand"
+      data-layout={fitModel.layout}
+    >
       {cards.map((cardId, index) => {
         const distance = index - midpoint;
-        const rotate = isRailLayout ? 0 : distance * spread;
+        const rotate = isRailLayout ? 0 : distance * fitModel.spread;
         const raise = isRailLayout ? 0 : Math.abs(distance) * Math.max(2, 18 / Math.max(cards.length, 2));
         return (
           <div
@@ -39,6 +122,7 @@ export function HandFan({
             <CardView
               cardId={cardId}
               size="lg"
+              context="hand"
               interactive={interactive}
               playable={playableCardIds.has(cardId)}
               selected={selectedCardId === cardId}

--- a/src/ui/layout/ActionRail.tsx
+++ b/src/ui/layout/ActionRail.tsx
@@ -4,6 +4,7 @@ interface ActionRailProps {
   isMandatoryPrompt: boolean;
   turnStatusText: string;
   legalActions: LegalAction[];
+  isPaused: boolean;
   showDebugActions: boolean;
   onToggleDebugActions: () => void;
 }
@@ -12,20 +13,23 @@ export function ActionRail({
   isMandatoryPrompt,
   turnStatusText,
   legalActions,
+  isPaused,
   showDebugActions,
   onToggleDebugActions,
 }: ActionRailProps) {
   return (
     <aside className="panel action-rail card-enter" aria-label="Turn action rail">
       <h3>Turn Actions</h3>
-      <p className={`turn-status ${isMandatoryPrompt ? 'is-required' : ''}`}>{turnStatusText}</p>
+      <p className={`turn-status ${isMandatoryPrompt ? 'is-required' : ''}`}>
+        {isPaused ? 'Game is paused. Resume from the top bar to continue.' : turnStatusText}
+      </p>
       <p className="action-rail-caption">
         {isMandatoryPrompt
           ? 'Resolve the required action in the active player panel.'
           : 'Use the active player panel below to play cards.'}
       </p>
       <div className="debug-actions">
-        <button type="button" onClick={onToggleDebugActions}>
+        <button type="button" onClick={onToggleDebugActions} disabled={isPaused}>
           {showDebugActions ? 'Hide' : 'Show'} All Legal Actions ({legalActions.length})
         </button>
         {showDebugActions && (

--- a/src/ui/screens/GameTableScreen.tsx
+++ b/src/ui/screens/GameTableScreen.tsx
@@ -28,6 +28,7 @@ interface PlayChooserState {
 interface GameTableScreenProps {
   game: GameState;
   prompt: TurnPrompt;
+  isPaused: boolean;
   legalActions: LegalAction[];
   contextualActions: LegalAction[];
   revealedPlayerId: string | null;
@@ -46,6 +47,8 @@ interface GameTableScreenProps {
   turnSnapshotsCount: number;
   showDebugActions: boolean;
   actionDetailText: (item: LegalAction) => string | null;
+  onPauseToggle: () => void;
+  onOpenSettings: () => void;
   onToggleDebugActions: () => void;
   onRunAction: (action: Action) => void;
   onCardClick: (cardId: string) => void;
@@ -56,7 +59,6 @@ interface GameTableScreenProps {
   onCloseChooser: () => void;
   onRevealTurn: () => void;
   onNavigateHome: () => void;
-  onEndMatch: () => void;
 }
 
 function colorLabel(color: PropertyColor): string {
@@ -82,6 +84,7 @@ function renderHiddenHand(cardCount: number) {
 export function GameTableScreen({
   game,
   prompt,
+  isPaused,
   legalActions,
   contextualActions,
   revealedPlayerId,
@@ -100,6 +103,8 @@ export function GameTableScreen({
   turnSnapshotsCount,
   showDebugActions,
   actionDetailText,
+  onPauseToggle,
+  onOpenSettings,
   onToggleDebugActions,
   onRunAction,
   onCardClick,
@@ -110,12 +115,11 @@ export function GameTableScreen({
   onCloseChooser,
   onRevealTurn,
   onNavigateHome,
-  onEndMatch,
 }: GameTableScreenProps) {
   const over = isGameOver(game);
 
   return (
-    <section className="game-table-screen">
+    <section className={`game-table-screen ${isPaused ? 'is-paused' : ''}`}>
       <TopBar
         title="Game Table"
         subtitle={prompt.text}
@@ -130,7 +134,8 @@ export function GameTableScreen({
         actions={(
           <>
             <button onClick={onNavigateHome}>Home</button>
-            <button onClick={onEndMatch}>End Match</button>
+            <button onClick={onOpenSettings}>Settings</button>
+            <button onClick={onPauseToggle}>{isPaused ? 'Resume' : 'Pause'}</button>
           </>
         )}
       />
@@ -140,6 +145,7 @@ export function GameTableScreen({
           isMandatoryPrompt={isMandatoryPrompt}
           turnStatusText={turnStatusText}
           legalActions={legalActions}
+          isPaused={isPaused}
           showDebugActions={showDebugActions}
           onToggleDebugActions={onToggleDebugActions}
         />
@@ -150,9 +156,9 @@ export function GameTableScreen({
               const canSeeHand = revealedPlayerId === player.id;
               const isCurrent = game.players[game.currentPlayerIndex].id === player.id;
               const isPromptPlayer = prompt.playerId === player.id;
-              const handInteractive = Boolean(canSeeHand && prompt.playerId === player.id && !over.done);
+              const handInteractive = Boolean(canSeeHand && prompt.playerId === player.id && !over.done && !isPaused);
               const isPaymentPayer = pendingPayment?.targetPlayerId === player.id;
-              const paymentSelectionEnabled = Boolean(isPaymentPayer && revealedPlayerId === player.id && !over.done);
+              const paymentSelectionEnabled = Boolean(isPaymentPayer && revealedPlayerId === player.id && !over.done && !isPaused);
               const inlineActions = isPromptPlayer
                 ? (
                     pendingPayment
@@ -198,7 +204,7 @@ export function GameTableScreen({
                           ) : (
                             <p className="payment-selected">Click cards in {player.name}&apos;s bank/properties to pay.</p>
                           )}
-                          <button type="button" onClick={onSubmitSelectedPayment} disabled={!paymentCanSubmit}>
+                          <button type="button" onClick={onSubmitSelectedPayment} disabled={!paymentCanSubmit || isPaused}>
                             Confirm Payment
                           </button>
                         </div>
@@ -206,7 +212,11 @@ export function GameTableScreen({
 
                       <div className="actions action-list inline-actions">
                         {inlineActions.map((item, index) => (
-                          <button key={`inline-${item.label}-${index}`} onClick={() => onRunAction(item.action)}>
+                          <button
+                            key={`inline-${item.label}-${index}`}
+                            onClick={() => onRunAction(item.action)}
+                            disabled={isPaused}
+                          >
                             {item.label}
                             {actionDetailText(item) ? <span className="action-detail">{actionDetailText(item)}</span> : null}
                           </button>
@@ -218,10 +228,10 @@ export function GameTableScreen({
 
                       {turnSnapshotsCount > 0 && prompt.kind === 'main' ? (
                         <div className="actions inline-actions">
-                          <button type="button" onClick={onUndoLastPlay}>
+                          <button type="button" onClick={onUndoLastPlay} disabled={isPaused}>
                             Undo Last Play
                           </button>
-                          <button type="button" onClick={onResetTurnPlays}>
+                          <button type="button" onClick={onResetTurnPlays} disabled={isPaused}>
                             Reset Turn Plays
                           </button>
                         </div>
@@ -239,7 +249,7 @@ export function GameTableScreen({
                           selectedCardId={selectedCardId}
                           onCardClick={onCardClick}
                           interactive={handInteractive}
-                          layout={player.hand.length > 10 ? 'rail' : 'fan'}
+                          fitMode="auto"
                         />
                       ) : (
                         <p>Empty</p>
@@ -309,7 +319,7 @@ export function GameTableScreen({
         </div>
       </div>
 
-      {chooser ? (
+      {chooser && !isPaused ? (
         <PlayChooser
           cardId={chooser.cardId}
           cardLabel={chooser.cardLabel}
@@ -323,7 +333,7 @@ export function GameTableScreen({
         />
       ) : null}
 
-      {shouldShowShield && !over.done ? (
+      {shouldShowShield && !over.done && !isPaused ? (
         <div className="shield" role="dialog" aria-modal="true">
           <div className="shield-card card-enter">
             <h3>Pass Device</h3>
@@ -331,6 +341,15 @@ export function GameTableScreen({
               Next action: <strong>{game.players.find((player) => player.id === prompt.playerId)?.name ?? prompt.playerId}</strong>
             </p>
             <button onClick={onRevealTurn}>Reveal Turn</button>
+          </div>
+        </div>
+      ) : null}
+
+      {isPaused && !over.done ? (
+        <div className="paused-overlay" role="dialog" aria-modal="true" aria-label="Game paused">
+          <div className="paused-card card-enter">
+            <h3>Game Paused</h3>
+            <p>Gameplay is locked until you press Resume in the top bar.</p>
           </div>
         </div>
       ) : null}

--- a/src/ui/screens/HomeScreen.tsx
+++ b/src/ui/screens/HomeScreen.tsx
@@ -3,9 +3,10 @@ interface HomeScreenProps {
   onNewGame: () => void;
   onResumeGame: () => void;
   onOpenStats: () => void;
+  onOpenSettings: () => void;
 }
 
-export function HomeScreen({ error, onNewGame, onResumeGame, onOpenStats }: HomeScreenProps) {
+export function HomeScreen({ error, onNewGame, onResumeGame, onOpenStats, onOpenSettings }: HomeScreenProps) {
   return (
     <section className="panel home-screen card-enter">
       <div className="home-hero">
@@ -18,6 +19,7 @@ export function HomeScreen({ error, onNewGame, onResumeGame, onOpenStats }: Home
         <button onClick={onNewGame}>New Game</button>
         <button onClick={onResumeGame}>Resume Saved Game</button>
         <button onClick={onOpenStats}>Stats & History</button>
+        <button onClick={onOpenSettings}>Settings</button>
       </div>
 
       {error ? <p className="error">{error}</p> : null}

--- a/src/ui/screens/SettingsScreen.tsx
+++ b/src/ui/screens/SettingsScreen.tsx
@@ -1,0 +1,94 @@
+import type { UiPreferencesV1 } from '../../persistence/storage';
+
+type DevSeedStatus = 'seeded' | 'already-populated' | 'reseeded' | null;
+
+interface SettingsScreenProps {
+  uiPreferences: UiPreferencesV1;
+  devSeedStatus: DevSeedStatus;
+  onToggleReducedEffects: (enabled: boolean) => void;
+  onChangeTextScale: (value: UiPreferencesV1['textScale']) => void;
+  onChangeTableDensity: (value: UiPreferencesV1['tableDensity']) => void;
+  onToggleDevMode: (enabled: boolean) => void;
+  onReseedDevData: () => void;
+  onBack: () => void;
+}
+
+function devStatusMessage(status: DevSeedStatus): string | null {
+  if (status === 'seeded') return 'Seeded medium sample stats and match history.';
+  if (status === 'already-populated') return 'Skipped auto-seed because match history already contains data.';
+  if (status === 'reseeded') return 'Replaced stats and match history with medium sample data.';
+  return null;
+}
+
+export function SettingsScreen({
+  uiPreferences,
+  devSeedStatus,
+  onToggleReducedEffects,
+  onChangeTextScale,
+  onChangeTableDensity,
+  onToggleDevMode,
+  onReseedDevData,
+  onBack,
+}: SettingsScreenProps) {
+  const statusMessage = devStatusMessage(devSeedStatus);
+
+  return (
+    <section className="panel settings-screen card-enter">
+      <h2>Settings</h2>
+      <p className="settings-subtitle">Control local display options, pause behavior, and development data tools.</p>
+
+      <section className="settings-section" aria-label="Display settings">
+        <h3>Display</h3>
+
+        <label className="settings-field settings-toggle">
+          <span>Reduced Celebration Effects</span>
+          <input
+            type="checkbox"
+            checked={uiPreferences.reducedEffects}
+            onChange={(event) => onToggleReducedEffects(event.target.checked)}
+          />
+        </label>
+
+        <label className="settings-field">
+          <span>Text Scale</span>
+          <select value={uiPreferences.textScale} onChange={(event) => onChangeTextScale(event.target.value as UiPreferencesV1['textScale'])}>
+            <option value="normal">Normal</option>
+            <option value="large">Large</option>
+          </select>
+        </label>
+
+        <label className="settings-field">
+          <span>Table Density</span>
+          <select value={uiPreferences.tableDensity} onChange={(event) => onChangeTableDensity(event.target.value as UiPreferencesV1['tableDensity'])}>
+            <option value="cozy">Cozy</option>
+            <option value="compact">Compact</option>
+          </select>
+        </label>
+      </section>
+
+      <section className="settings-section" aria-label="Development tools">
+        <h3>Development Tools</h3>
+        <label className="settings-field settings-toggle">
+          <span>Dev Mode</span>
+          <input
+            type="checkbox"
+            checked={uiPreferences.devModeEnabled}
+            onChange={(event) => onToggleDevMode(event.target.checked)}
+          />
+        </label>
+        <div className="actions">
+          <button type="button" onClick={onReseedDevData} disabled={!uiPreferences.devModeEnabled}>
+            Reseed Stats & History
+          </button>
+        </div>
+        {statusMessage ? <p className="settings-status">{statusMessage}</p> : null}
+      </section>
+
+      <div className="actions">
+        <button type="button" onClick={onBack}>
+          Back
+        </button>
+      </div>
+    </section>
+  );
+}

--- a/src/ui/theme/components/cards.css
+++ b/src/ui/theme/components/cards.css
@@ -16,21 +16,20 @@
 }
 
 .card-view {
-  --card-pad: 0.4rem;
-  --card-accent-height: 10px;
-  --card-value-size: 0.75rem;
-  --card-title-size: 0.72rem;
-  --card-subtitle-size: 0.64rem;
-  --card-meta-size: 0.56rem;
-  --card-annotation-size: 0.58rem;
+  --card-pad: 0.38rem;
+  --card-accent-height: 12px;
+  --card-value-size: 0.8rem;
+  --card-title-size: 0.76rem;
+  --card-subtitle-size: 0.63rem;
+  --card-meta-size: 0.55rem;
+  --card-annotation-size: 0.56rem;
   --card-title-lines: 2;
-  --card-subtitle-lines: 3;
-  --card-meta-lines: 2;
+  --card-subtitle-lines: 2;
 
-  border-radius: 12px;
-  border: 1px solid #d8ccb6;
+  border-radius: 11px;
+  border: 2px solid #d2c8b7;
   background: #fff;
-  box-shadow: 0 8px 16px rgba(0, 0, 0, 0.12);
+  box-shadow: 0 10px 16px rgba(0, 0, 0, 0.16);
   padding: 0;
   text-align: left;
   color: #1f2b34;
@@ -39,12 +38,12 @@
 }
 
 .card-view.card-variant-premium {
-  border-color: #bdc9d8;
+  border-color: #aebed0;
   box-shadow: 0 10px 18px rgba(2, 12, 20, 0.26);
 }
 
 .card-view.card-elevation-raised {
-  box-shadow: 0 14px 22px rgba(2, 10, 16, 0.34);
+  box-shadow: 0 15px 24px rgba(2, 10, 16, 0.34);
 }
 
 .card-view.tone-warning {
@@ -56,48 +55,37 @@
 }
 
 .card-size-sm {
-  --card-pad: 0.34rem;
+  --card-pad: 0.3rem;
   --card-accent-height: 8px;
-  --card-value-size: 0.68rem;
-  --card-title-size: 0.56rem;
-  --card-subtitle-size: 0.5rem;
-  --card-meta-size: 0.48rem;
-  --card-annotation-size: 0.48rem;
+  --card-value-size: 0.63rem;
+  --card-title-size: 0.54rem;
+  --card-subtitle-size: 0.48rem;
+  --card-meta-size: 0.45rem;
+  --card-annotation-size: 0.46rem;
   --card-title-lines: 2;
   --card-subtitle-lines: 2;
-  --card-meta-lines: 1;
   width: 72px;
   height: 104px;
 }
 
 .card-size-md {
-  --card-title-lines: 2;
-  --card-subtitle-lines: 3;
-  --card-meta-lines: 2;
   width: 84px;
   height: 120px;
 }
 
 .card-size-lg {
-  --card-pad: 0.46rem;
-  --card-title-size: 0.78rem;
-  --card-subtitle-size: 0.68rem;
-  --card-meta-size: 0.6rem;
-  --card-title-lines: 2;
-  --card-subtitle-lines: 3;
-  --card-meta-lines: 2;
-  width: 108px;
-  height: 152px;
+  width: var(--hand-card-w, 118px);
+  height: var(--hand-card-h, 170px);
 }
 
 .card-face {
   display: flex;
   flex-direction: column;
-  gap: 0.1rem;
+  gap: 0.16rem;
   height: 100%;
   min-height: 0;
   padding: var(--card-pad);
-  background: linear-gradient(165deg, #fff, #f5f3ee);
+  background: linear-gradient(165deg, #fff, #f4f1e8);
   border-top: var(--card-accent-height) solid var(--card-accent);
 }
 
@@ -106,7 +94,7 @@
   border-top: var(--card-accent-height) solid transparent;
   background:
     linear-gradient(90deg, var(--card-accent) 0 50%, var(--card-accent-split) 50% 100%) top / 100% var(--card-accent-height) no-repeat,
-    linear-gradient(165deg, #fff, #f5f3ee);
+    linear-gradient(165deg, #fff, #f4f1e8);
 }
 
 .theme-rent-any .card-face {
@@ -125,26 +113,47 @@
       var(--card-color-railroad) 80% 90%,
       var(--card-color-utility) 90% 100%
     ) top / 100% var(--card-accent-height) no-repeat,
-    linear-gradient(165deg, #fff, #f5f3ee);
+    linear-gradient(165deg, #fff, #f4f1e8);
 }
 
 .card-face > span {
   min-width: 0;
 }
 
+.card-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.18rem;
+}
+
 .card-value {
-  justify-self: end;
+  border: 1px solid rgba(36, 56, 73, 0.3);
+  border-radius: 999px;
+  padding: 0.05rem 0.3rem;
   font-weight: 800;
   font-size: var(--card-value-size);
-  line-height: 1.1;
-  margin-bottom: 0.08rem;
-  align-self: flex-end;
+  line-height: 1.2;
+  color: #1e2d3a;
+  background: rgba(248, 253, 255, 0.95);
+}
+
+.card-badge {
+  border-radius: 6px;
+  padding: 0.04rem 0.28rem;
+  font-size: calc(var(--card-subtitle-size) * 0.95);
+  line-height: 1.2;
+  font-weight: 700;
+  color: #113450;
+  background: rgba(188, 220, 243, 0.8);
+  border: 1px solid rgba(63, 111, 145, 0.35);
+  text-transform: uppercase;
 }
 
 .card-title {
-  font-weight: 700;
+  font-weight: 800;
   font-size: var(--card-title-size);
-  line-height: 1.2;
+  line-height: 1.16;
   color: #1f2b34;
   overflow-wrap: anywhere;
   display: -webkit-box;
@@ -155,8 +164,8 @@
 
 .card-subtitle {
   font-size: var(--card-subtitle-size);
-  line-height: 1.2;
-  color: #5c6973;
+  line-height: 1.15;
+  color: #425664;
   text-transform: capitalize;
   overflow-wrap: anywhere;
   display: -webkit-box;
@@ -165,16 +174,86 @@
   overflow: hidden;
 }
 
-.card-meta {
-  margin-top: auto;
-  font-size: var(--card-meta-size);
+.card-context-hand.card-size-lg {
+  --card-pad: 0.48rem;
+  --card-value-size: 0.9rem;
+  --card-title-size: 0.84rem;
+  --card-subtitle-size: 0.66rem;
+  --card-meta-size: 0.62rem;
+}
+
+.card-color-label {
+  font-size: calc(var(--card-subtitle-size) * 0.95);
   line-height: 1.2;
-  color: #314452;
-  overflow-wrap: anywhere;
-  display: -webkit-box;
-  -webkit-box-orient: vertical;
-  -webkit-line-clamp: var(--card-meta-lines);
-  overflow: hidden;
+  font-weight: 700;
+  color: #203645;
+  border-radius: 5px;
+  background: rgba(230, 239, 245, 0.9);
+  border: 1px solid rgba(94, 122, 146, 0.32);
+  padding: 0.08rem 0.24rem;
+}
+
+.card-rent {
+  margin-top: auto;
+  border-radius: 8px;
+  border: 1px solid rgba(62, 89, 111, 0.5);
+  background: rgba(245, 250, 253, 0.92);
+  padding: 0.16rem;
+}
+
+.card-rent-label {
+  display: block;
+  font-size: calc(var(--card-meta-size) * 1.05);
+  font-weight: 800;
+  line-height: 1.1;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+  color: #2b4658;
+}
+
+.card-rent-grid {
+  margin-top: 0.12rem;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(26px, 1fr));
+  gap: 0.12rem;
+}
+
+.card-rent-step {
+  display: grid;
+  gap: 0;
+  justify-items: center;
+  border-radius: 6px;
+  border: 1px solid rgba(77, 108, 132, 0.42);
+  background: #f3f8fb;
+  color: #2f4656;
+  font-size: var(--card-meta-size);
+  line-height: 1.05;
+  padding: 0.08rem 0.1rem;
+}
+
+.card-rent-step.is-fullset {
+  border-color: #1e7a5f;
+  background: #d9f4e9;
+  color: #11533f;
+  font-weight: 800;
+}
+
+.card-rent.is-compact {
+  padding: 0.1rem;
+}
+
+.card-rent.is-compact .card-rent-label {
+  font-size: 0.42rem;
+}
+
+.card-rent.is-compact .card-rent-grid {
+  gap: 0.08rem;
+}
+
+.card-rent.is-compact .card-rent-step {
+  font-size: 0.42rem;
+  border-radius: 4px;
+  padding: 0.05rem 0.08rem;
 }
 
 .card-annotation {
@@ -229,19 +308,27 @@
 }
 
 .hand-fan {
+  --hand-card-w: 118px;
+  --hand-card-h: 170px;
+  --fan-overlap: 42px;
+  --rail-gap: 14px;
+
   display: flex;
   justify-content: center;
   align-items: flex-end;
   padding: 0.9rem 0.35rem 0.4rem;
-  min-height: 186px;
+  min-height: 208px;
   margin-top: 0.45rem;
   border-radius: 12px;
-  background: linear-gradient(180deg, rgba(45, 122, 94, 0.15), rgba(45, 122, 94, 0.04));
-  overflow: hidden;
+  background: linear-gradient(180deg, rgba(45, 122, 94, 0.16), rgba(45, 122, 94, 0.05));
+}
+
+.hand-fan.is-fan {
+  overflow-x: hidden;
 }
 
 .hand-fan-card {
-  margin-left: -42px;
+  margin-left: calc(var(--fan-overlap) * -1);
   transform-origin: bottom center;
   transition: transform var(--motion-fast) var(--ease-standard);
 }
@@ -258,12 +345,25 @@
 .hand-fan.is-rail {
   justify-content: flex-start;
   overflow-x: auto;
-  min-height: 154px;
-  padding-bottom: 0.55rem;
+  gap: var(--rail-gap);
+  padding: 0.75rem 0.65rem 0.75rem;
+  min-height: 186px;
+  scroll-snap-type: x proximity;
 }
 
 .hand-fan.is-rail .hand-fan-card {
-  margin-left: -28px;
+  margin-left: 0;
+  flex: 0 0 auto;
+  scroll-snap-align: start;
+}
+
+.hand-fan.is-rail .hand-fan-card:first-child {
+  margin-left: 0;
+}
+
+.hand-fan.is-rail .hand-fan-card:hover,
+.hand-fan.is-rail .hand-fan-card:focus-within {
+  transform: translateY(-4px) !important;
 }
 
 .hidden-hand-wrap {
@@ -312,19 +412,19 @@
   margin-top: 0.35rem;
 }
 
+@media (max-width: 980px) {
+  .hand-fan {
+    min-height: 190px;
+  }
+}
+
 @media (max-width: 720px) {
   .hand-fan {
-    justify-content: flex-start;
-    overflow-x: auto;
-    padding-bottom: 0.8rem;
-  }
-
-  .hand-fan-card {
-    margin-left: -30px;
+    min-height: 176px;
   }
 
   .card-size-lg {
-    width: 94px;
-    height: 134px;
+    width: var(--hand-card-w, 108px);
+    height: var(--hand-card-h, 154px);
   }
 }

--- a/src/ui/theme/components/layout.css
+++ b/src/ui/theme/components/layout.css
@@ -174,6 +174,34 @@
   margin: 0.2rem 0;
 }
 
+.game-table-screen.is-paused .top-bar {
+  position: relative;
+  z-index: calc(var(--z-shield) + 1);
+}
+
+.paused-overlay {
+  position: fixed;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  z-index: var(--z-shield);
+  background: rgba(6, 11, 18, 0.84);
+}
+
+.paused-card {
+  width: min(520px, calc(100% - 2rem));
+  border-radius: 14px;
+  border: 2px solid #4f7390;
+  background: linear-gradient(170deg, rgba(12, 28, 44, 0.97), rgba(8, 19, 30, 0.96));
+  box-shadow: var(--shadow-md);
+  padding: 1.35rem;
+  text-align: center;
+}
+
+.paused-card p {
+  margin: 0.5rem 0 0;
+}
+
 .shield {
   position: fixed;
   inset: 0;

--- a/src/ui/theme/screens/settings.css
+++ b/src/ui/theme/screens/settings.css
@@ -1,0 +1,48 @@
+.settings-screen {
+  background:
+    radial-gradient(circle at 80% 8%, rgba(86, 174, 222, 0.18), transparent 36%),
+    radial-gradient(circle at 12% 88%, rgba(125, 223, 176, 0.14), transparent 42%),
+    linear-gradient(160deg, rgba(11, 24, 37, 0.95), rgba(8, 19, 30, 0.92));
+}
+
+.settings-subtitle {
+  margin: 0.34rem 0 0.7rem;
+}
+
+.settings-section {
+  border: 1px solid #36556f;
+  border-radius: var(--radius-md);
+  background: rgba(8, 24, 37, 0.9);
+  padding: 0.8rem;
+  margin-top: 0.7rem;
+}
+
+.settings-section h3 {
+  margin-bottom: 0.45rem;
+}
+
+.settings-field {
+  margin: 0.55rem 0;
+}
+
+.settings-toggle {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.7rem;
+}
+
+.settings-toggle input[type='checkbox'] {
+  width: 1rem;
+  height: 1rem;
+  min-height: unset;
+}
+
+.settings-status {
+  margin: 0.5rem 0 0;
+  padding: 0.45rem 0.55rem;
+  border-radius: 8px;
+  border: 1px solid #3e6d66;
+  background: rgba(18, 56, 50, 0.45);
+  color: #bdeed9;
+}


### PR DESCRIPTION
## Summary
- loosen card and layout spacing so card view and hand fan feel less cramped while keeping modular theme structure
- refresh supporting styles/screens plus README/docs to reflect the updated settings and visual options
- update persistence/stats fixtures and tests to align with the UI changes and ensure coverage

## Testing
- Not run (not requested)