### PR TITLE
Add LAN dev scripts and docs for simplified multiplayer startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,10 @@ Open the local URL shown by Vite (usually `http://localhost:5173`).
 ## Scripts
 
 - `npm run dev` - start local dev server
+- `npm run dev:all` - start UI + multiplayer server for same-machine local development
+- `npm run dev:lan` - start Vite on LAN (`0.0.0.0:5173`) for cross-device testing
+- `npm run dev:lan:all` - start LAN UI + multiplayer server together for two-device local play
+- `npm run lan` - alias for `npm run dev:lan:all`
 - `npm run dev:multiplayer-server` - start the Node multiplayer API for local backend development
 - `npm run build` - type-check and build production assets
 - `npm run preview` - preview the production build locally
@@ -148,6 +152,12 @@ See `.env.example` for the expected variable.
 
 For local multiplayer development, the backend service is required.
 Use the one-command startup:
+
+1. Two-device LAN host flow: `npm run dev:lan:all`
+2. Share the Vite `Network` URL (example: `http://192.168.1.123:5173`) with Player 2.
+3. Player 2 opens that URL, goes to `Multiplayer`, enters name + room code, and joins.
+
+For same-machine development, you can still run:
 
 1. UI + multiplayer server together: `npm run dev:all`
 

--- a/docs/LLM_AGENT_GUIDE.md
+++ b/docs/LLM_AGENT_GUIDE.md
@@ -24,9 +24,11 @@ Purpose: give coding agents enough context to make correct, low-regression chang
   - Heuristic and rollout decision helpers plus explainable coach hint generation.
 - `src/network/`
   - Hosted multiplayer client API wrappers (`src/network/multiplayerClient.ts`) for room create/join/reconnect/start/state/action/leave plus pause/resume/undo/reset-turn/checkpoint flows.
+  - In local dev, Vite proxies `/api/multiplayer` to `http://localhost:8787` so LAN clients can use same-origin API calls from the UI host URL.
   - Legacy LAN wrappers remain for development fallback.
 - `apps/server/`
   - Multiplayer API server scaffold with room lifecycle, reconnect windows, host migration, revision-guarded mutations, turn snapshots, checkpoints, and best-effort snapshot persistence.
+  - Recommended two-device startup command: `npm run dev:lan:all` (LAN UI + multiplayer server).
 - `src/ui/` + `src/App.tsx`
   - `App.tsx` owns state/actions and passes typed props to screen containers.
   - `src/app/useFeedback.ts` encapsulates sound/haptic emission.

--- a/docs/NEXT_CODEX_MULTIPLAYER.md
+++ b/docs/NEXT_CODEX_MULTIPLAYER.md
@@ -8,7 +8,9 @@ Purpose: build on shipped multiplayer gameplay parity by reducing onboarding fri
 - Host-only room controls exist for pause/resume and checkpoint save/load/delete.
 - Active prompt player controls include undo/reset-turn backed by server-authoritative snapshots.
 - Multiplayer mutations are revision-guarded to reduce stale write conflicts.
-- Local development supports one-command startup via `npm run dev:all`.
+- LAN startup is simplified for non-technical testing via `npm run dev:lan:all` with Vite proxying `/api/multiplayer` to the local API server.
+- Multiplayer lobby includes `Copy Room Code` to reduce manual code-sharing friction.
+- Same-machine local development still supports one-command startup via `npm run dev:all`.
 
 ## Next Objective
 

--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
   "scripts": {
     "dev": "vite",
     "dev:all": "concurrently --kill-others --names \"ui,server\" \"npm run dev -- --open\" \"npm run dev:multiplayer-server\"",
+    "dev:lan": "vite --host 0.0.0.0 --port 5173",
+    "dev:lan:all": "concurrently --kill-others --names \"ui,server\" \"npm run dev:lan\" \"npm run dev:multiplayer-server\"",
+    "lan": "npm run dev:lan:all",
     "dev:multiplayer-server": "node --import tsx/esm apps/server/src/index.ts",
     "build": "tsc -b && vite build",
     "lint": "eslint .",

--- a/src/test/app.test.tsx
+++ b/src/test/app.test.tsx
@@ -814,7 +814,7 @@ describe('App', () => {
     fireEvent.click(screen.getByRole('button', { name: /play multiplayer/i }));
 
     expect(await screen.findByText(/multiplayer server not reachable at/i)).toBeInTheDocument();
-    expect(screen.getByText(/run npm run dev:all/i)).toBeInTheDocument();
+    expect(screen.getByText(/run npm run dev:lan:all/i)).toBeInTheDocument();
 
     fetchSpy.mockRestore();
   });

--- a/src/ui/screens/MultiplayerScreen.tsx
+++ b/src/ui/screens/MultiplayerScreen.tsx
@@ -62,6 +62,12 @@ export function MultiplayerScreen({
   onLeaveRoom,
   onBack,
 }: MultiplayerScreenProps) {
+  const copyRoomCode = () => {
+    if (!session) return;
+    if (typeof navigator === 'undefined' || !navigator.clipboard?.writeText) return;
+    void navigator.clipboard.writeText(session.roomCode);
+  };
+
   return (
     <section className="panel setup-screen card-enter">
       <h2>Multiplayer</h2>
@@ -74,7 +80,7 @@ export function MultiplayerScreen({
       {healthOk === false ? (
         <p className="error">
           {isLocalDevApi
-            ? `Multiplayer server not reachable at ${apiBase}. Run npm run dev:all.`
+            ? `Multiplayer server not reachable at ${apiBase}. For two-device LAN play run npm run dev:lan:all.`
             : 'Multiplayer service is currently unreachable. Please try again in a moment.'}
         </p>
       ) : null}
@@ -113,6 +119,9 @@ export function MultiplayerScreen({
             <p>Status: {connectionLabel(connectionState)}</p>
             <p>Rejoin window: {deadlineLabel(session.reconnectDeadlineMs)}</p>
             <div className="actions">
+              <button type="button" onClick={copyRoomCode} disabled={loading}>
+                Copy Room Code
+              </button>
               <button type="button" onClick={onRefresh} disabled={loading}>
                 Refresh
               </button>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,6 +3,14 @@ import react from '@vitejs/plugin-react';
 
 export default defineConfig({
   plugins: [react()],
+  server: {
+    proxy: {
+      '/api/multiplayer': {
+        target: 'http://localhost:8787',
+        changeOrigin: true,
+      },
+    },
+  },
   test: {
     environment: 'jsdom',
     setupFiles: './src/test/setup.ts',


### PR DESCRIPTION
## Summary
- add LAN-focused npm scripts and Vite proxy so the UI host can serve `/api/multiplayer` directly
- update multiplayer UI messaging, docs, and tests to drive users toward the new `npm run dev:lan:all` workflow
- add a copy-room-code button to the multiplayer lobby so hosts can share codes without manual selection

## Testing
- Not run (not requested)